### PR TITLE
Added Namespace key to firewall config

### DIFF
--- a/src/ZfcRbac/Firewall/Controller.php
+++ b/src/ZfcRbac/Firewall/Controller.php
@@ -13,9 +13,9 @@ class Controller extends AbstractFirewall
                 $rule['roles'] = array($rule['roles']);
             }
             if (isset($rule['action'])) {
-                $this->rules[$rule['controller']][$rule['action']] = $rule['roles'];
+                $this->rules[$rule['namespace']][$rule['controller']][$rule['action']] = $rule['roles'];
             } else {
-                $this->rules[$rule['controller']] = $rule['roles'];
+                $this->rules[$rule['namespace']][$rule['controller']] = $rule['roles'];
             }
         }
     }
@@ -30,14 +30,15 @@ class Controller extends AbstractFirewall
     public function isGranted($resource)
     {
         $resource   = explode(':', $resource);
-        $controller = $resource[0];
+        $namespace  = $resource[0];
+        $controller = $resource[1];
         $action     = isset($resource[1]) ? $resource[1] : null;
 
         // Check action first
-        if (isset($this->rules[$controller][$action])) {
-            $roles = $this->rules[$controller][$action];
-        } else if (isset($this->rules[$controller])) {
-            $roles = $this->rules[$controller];
+        if (isset($this->rules[$namespace][$controller][$action])) {
+            $roles = $this->rules[$namespace][$controller][$action];
+        } else if (isset($this->rules[$namespace][$controller])) {
+            $roles = $this->rules[$namespace][$controller];
         } else {
             return true;
         }

--- a/src/ZfcRbac/Firewall/Listener/Controller.php
+++ b/src/ZfcRbac/Firewall/Listener/Controller.php
@@ -11,9 +11,10 @@ class Controller
         $app        = $e->getTarget();
         $security   = $app->getServiceManager()->get('ZfcRbac\Service\Rbac');
         $match      = $app->getMvcEvent()->getRouteMatch();
-        $controller = $match->getParam('controller');
+        $controller = strtolower(str_replace($match->getParam('__NAMESPACE__').'\\', '', $match->getParam('controller')));
         $action     = $match->getParam('action');
-        $resource   = sprintf('%s:%s', $controller, $action);
+        $namespace  = $match->getParam('__NAMESPACE__');
+        $resource   = sprintf('%s:%s:%s', $namespace, $controller, $action);
 
         try {
             if (!$security->getFirewall('controller')->isGranted($resource)) {


### PR DESCRIPTION
Dont know if this is the right way todo it, but i couldnt get the Firwall to work, as $match->getParam('controller') always was a namespace not the action name string.

So i added the namespace to the config array. New Firewall config looks like this:

```
            'firewalls' => array(
                    'ZfcRbac\Firewall\Controller' => array(
                            array('namespace' => 'Admin\Controller', 'controller' => 'index', 'action' => 'index', 'roles' => 'admin'),
                            array('namespace' => 'Admin\Controller', 'controller' => 'index', 'action' => 'agencydash', 'roles' => 'admin')
                    )
               )
```
