### PR TITLE
Remove warning for Static function

### DIFF
--- a/src/ZfcRbac/Provider/AbstractProvider.php
+++ b/src/ZfcRbac/Provider/AbstractProvider.php
@@ -4,20 +4,9 @@ namespace ZfcRbac\Provider;
 
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\Permissions\Rbac\Rbac;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-abstract class AbstractProvider implements ListenerAggregateInterface
+abstract class AbstractProvider implements ListenerAggregateInterface, ProviderInterface
 {
-    /**
-     * Factory to create the provider.
-     *
-     * @static
-     * @param \Zend\ServiceManager\ServiceLocatorInterface $sl
-     * @param mixed $spec
-     * @return mixed
-     */
-    abstract public static function factory(ServiceLocatorInterface $sl, array $spec);
-
     /**
      * Recursive function to add roles according to their parent role.
      *

--- a/src/ZfcRbac/Provider/ProviderInterface.php
+++ b/src/ZfcRbac/Provider/ProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ZfcRbac\Provider;
+
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+interface ProviderInterface
+{
+    /**
+     * Factory to create the provider.
+     *
+     * @static
+     * @param \Zend\ServiceManager\ServiceLocatorInterface $sl
+     * @param mixed $spec
+     * @return mixed
+     */
+    public static function factory(ServiceLocatorInterface $sl, array $spec);
+}


### PR DESCRIPTION
My mistake from my previous cleanup. Writing an abstract static function raises a warning, this fix that.
