### PR TITLE
Allow easy usage of custom Role class 

### DIFF
--- a/src/ZfcRbac/Provider/AbstractProvider.php
+++ b/src/ZfcRbac/Provider/AbstractProvider.php
@@ -4,6 +4,7 @@ namespace ZfcRbac\Provider;
 
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\Permissions\Rbac\Rbac;
+use Zend\Permissions\Rbac\AbstractRole;
 
 abstract class AbstractProvider implements ListenerAggregateInterface, ProviderInterface
 {
@@ -27,8 +28,10 @@ abstract class AbstractProvider implements ListenerAggregateInterface, ProviderI
                 $rbac->addRole($role);
             }
 
-            if (!empty($roles[$role])) {
-                $this->recursiveroles($rbac, $roles, $role);
+            $name = ($role instanceof AbstractRole) ? $role->getName() : $role;
+            
+            if (!empty($roles[$name])) {
+                $this->recursiveroles($rbac, $roles, $name);
             }
         }
     }

--- a/src/ZfcRbac/Provider/AdjacencyList/Role/DoctrineDbal.php
+++ b/src/ZfcRbac/Provider/AdjacencyList/Role/DoctrineDbal.php
@@ -68,7 +68,7 @@ class DoctrineDbal extends AbstractProvider
         $builder = new QueryBuilder($this->connection);
         $options = $this->options;
 
-        $builder->select("role.{$options->getNameColumn()} AS name, parent.{$options->getNameColumn()} AS parent")
+        $builder->select("role.{$options->getNameColumn()} AS name, role.{$options->getIdColumn()} as id, parent.{$options->getNameColumn()} AS parent")
                 ->from($options->getTable(), 'role')
                 ->leftJoin(
                     'role',
@@ -84,10 +84,20 @@ class DoctrineDbal extends AbstractProvider
             $parentName = isset($row['parent']) ? $row['parent'] : 0;
             unset($row['parent']);
 
-            $roles[$parentName][] = $row['name'];
+            $roles[$parentName][] = $this->createRole($row);
         }
 
         $this->recursiveRoles($e->getRbac(), $roles);
+    }
+    
+    /**
+     * Factory to create a custom role object
+     * 
+     * @param array $row
+     * @return string|AbstractRole
+     */
+    protected function createRole(array $row) {
+        return $row['name'];
     }
 
     /**
@@ -113,6 +123,6 @@ class DoctrineDbal extends AbstractProvider
             throw new DomainException('Failed to find DBAL Connection');
         }
 
-        return new DoctrineDbal($adapter, $options);
+        return new static($adapter, $options);
     }
 }


### PR DESCRIPTION
To use a custom class inherit from  from AdjacencyList/Role/DoctrineDbal.php and overwrite createRole()  according to your needs. 

``` php
class MyProvider extends DoctrineDbal {

  protected function createRole(array $row) {
     $role = new My\Custom\Role($row['name']);
     // Optional: $role->setId($row['id']);
    return $role;
  }

}
```
