### PR TITLE
RbacOptions :  mutators

### DIFF
--- a/src/ZfcRbac/Service/RbacOptions.php
+++ b/src/ZfcRbac/Service/RbacOptions.php
@@ -189,4 +189,23 @@ class RbacOptions extends AbstractOptions
     {
         return $this->template;
     }
+    
+    /**
+     * @return bool
+     */
+    public function getEnableLazyProviders()
+    {
+    	return $this->enableLazyProviders;
+    }
+
+    /**
+     * @param bool $value
+     * @return RbacOptions
+     */
+    public function setEnableLazyProviders($value)
+    {
+    	$this->enableLazyProviders = (bool) $value;
+    	return $this;
+    }
+
 }


### PR DESCRIPTION
Lacking mutators for $enableLazyProviders in RbacOptions
