### PR TITLE
Added ON UPDATE and ON DELETE clauses to FOREIGN KEYS.

### DIFF
--- a/data/schema.sql
+++ b/data/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE `rbac_role` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;
 
 ALTER TABLE `rbac_role`
-  ADD CONSTRAINT `rbac_role_ibfk_1` FOREIGN KEY (`parent_role_id`) REFERENCES `rbac_role` (`role_id`);
+  ADD CONSTRAINT `rbac_role_ibfk_1` FOREIGN KEY (`parent_role_id`) REFERENCES `rbac_role` (`role_id`) ON UPDATE CASCADE ON DELETE SET NULL;
 
 
 CREATE TABLE `rbac_role_permission` (
@@ -26,5 +26,5 @@ CREATE TABLE `rbac_role_permission` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE `rbac_role_permission`
-  ADD CONSTRAINT `rbac_role_permission_ibfk_1` FOREIGN KEY (`role_id`) REFERENCES `rbac_role` (`role_id`),
-  ADD CONSTRAINT `rbac_role_permission_ibfk_2` FOREIGN KEY (`perm_id`) REFERENCES `rbac_permission` (`perm_id`);
+  ADD CONSTRAINT `rbac_role_permission_ibfk_1` FOREIGN KEY (`role_id`) REFERENCES `rbac_role` (`role_id`) ON UPDATE CASCADE ON DELETE CASCADE,
+  ADD CONSTRAINT `rbac_role_permission_ibfk_2` FOREIGN KEY (`perm_id`) REFERENCES `rbac_permission` (`perm_id`) ON UPDATE CASCADE ON DELETE CASCADE;


### PR DESCRIPTION
ON UPDATE and ON DELETE clauses will prevent errors while i.e. deleting roles containing a parent role in case of foreign key constraints.
