### PR TITLE
Variable naming collision

### DIFF
--- a/src/ZfcRbac/Firewall/Listener/Controller.php
+++ b/src/ZfcRbac/Firewall/Listener/Controller.php
@@ -10,9 +10,9 @@ class Controller
     /**
      * @param MvcEvent $e
      */
-    public static function onRoute(MvcEvent $e)
+    public static function onRoute(MvcEvent $event)
     {
-        $app         = $e->getTarget();
+        $app         = $event->getTarget();
         $rbacService = $app->getServiceManager()->get('ZfcRbac\Service\Rbac');
         $match       = $app->getMvcEvent()->getRouteMatch();
         $controller  = $match->getParam('controller');
@@ -27,11 +27,11 @@ class Controller
             //if Exception, default to unauthorized
         }
         try {
-            $e->setError($rbacService::ERROR_CONTROLLER_UNAUTHORIZED)
+            $event->setError($rbacService::ERROR_CONTROLLER_UNAUTHORIZED)
                 ->setParam('identity', $rbacService->getIdentity())
                 ->setParam('controller', $controller)
                 ->setParam('action', $action);
-            $app->getEventManager()->trigger('dispatch.error', $e);
+            $app->getEventManager()->trigger('dispatch.error', $event);
         } catch (InvalidArgumentException $e) {
             return;
         }


### PR DESCRIPTION
MvcEvent captured by $e var is in collision with InvalidArgumentException From the first "catch" block
