### PR TITLE
Fixed AbstractProvider, add a child role as an instance from the rbac

### DIFF
--- a/src/ZfcRbac/Provider/AbstractProvider.php
+++ b/src/ZfcRbac/Provider/AbstractProvider.php
@@ -21,7 +21,8 @@ abstract class AbstractProvider implements ProviderInterface
         }
         foreach ((array) $roles[$parentName] as $role) {
             if ($parentName) {
-                $rbac->getRole($parentName)->addChild($role);
+                $childRole = $rbac->hasRole($role) ? $rbac->getRole($role) : $role;
+                $rbac->getRole($parentName)->addChild($childRole);
             } else {
                 $rbac->addRole($role);
             }


### PR DESCRIPTION
Hi, I think there is an issue when I have the role e.g. user as a child in two (or more) different roles. It is added as a new instance which does not have the permissions. So I added the check if the rbac has the role, then adds its instance as a child.
