### PR TITLE
Validate has identity exists and try to use it before attempting to pull...

### DIFF
--- a/src/ZfcRbac/Collector/RbacCollector.php
+++ b/src/ZfcRbac/Collector/RbacCollector.php
@@ -65,9 +65,11 @@ class RbacCollector implements CollectorInterface, Serializable
         $this->collectedOptions = $rbacConfig;
         $identityProvider = $sm->get($rbacConfig['identity_provider']);
         $rbacService = $sm->get('ZfcRbac\Service\Rbac');
-        if (method_exists($identityProvider, 'getIdentity')) {
-            $identity = $identityProvider->getIdentity();
-            $this->collectedRoles = $identity->getRoles();
+        if (method_exists($identityProvider, 'getIdentity') && method_exists($identityProvider, 'hasIdentity')) {
+            if ($identityProvider->hasIdentity()) {
+                $identity = $identityProvider->getIdentity();
+                $this->collectedRoles = $identity->getRoles();
+            }
         } else {
             $rbac = $rbacService->getRbac();
             $roles = array();


### PR DESCRIPTION
Fix for identity providers that provide hasIdentity to verify if the identity exists prior to pulling the user's roles.
