### PR TITLE
Route matching must be anchored to the start of the string

### DIFF
--- a/src/ZfcRbac/Firewall/Route.php
+++ b/src/ZfcRbac/Firewall/Route.php
@@ -42,10 +42,12 @@ class Route extends AbstractFirewall
 
             $this->permissions[] = isset($rule['permissions']) ? $rule['permissions'] : array();
 
-            $regex[] = str_replace('/', '\/', '(' . $rule['route'] . ')');
+            $strRegex = '('. $rule['route'] . ')';
+            $strRegex = str_replace('/*', '/?.*', $strRegex);
+            $regex[] = $strRegex;
         }
 
-        $this->ruleRegex = sprintf('/^(%s)/', implode('|', $regex));
+        $this->ruleRegex = sprintf('#^(?:%s)#', implode('|', $regex));
     }
 
     /**

--- a/tests/ZfcRbacTest/Firewall/RouteTest.php
+++ b/tests/ZfcRbacTest/Firewall/RouteTest.php
@@ -12,19 +12,23 @@ class RouteTest extends PHPUnit_Framework_TestCase
         return array(
             array(
                 array(
-                    'rules' => array(
-                        'route'       => 'application/private/*',
-                        'roles'       => 'user'
-                    )
+                    array(
+                        'route' => 'application/private/*',
+                        'roles' => 'user'
+                    ),
+                    array(
+                        'route' => 'application/other/*',
+                        'roles' => 'user'
+                    ),
                 ),
                 array(
                     array(
                         'resource' => 'application/private',
-                        'result'   => false
+                        'result' => false
                     ),
                     array(
                         'resource' => 'application',
-                        'result'   => true
+                        'result' => true
                     ),
                 )
             ),
@@ -32,22 +36,22 @@ class RouteTest extends PHPUnit_Framework_TestCase
             array(
                 array(
                     array(
-                        'route'       => 'application/private/*',
+                        'route' => 'application/private/*',
                         'permissions' => 'PRIVATE_PERMISSION',
                     ),
                     array(
-                        'route'       => 'application/secret/*',
+                        'route' => 'application/secret/*',
                         'permissions' => 'SECRET_PERMISSION',
                     )
                 ),
                 array(
                     array(
                         'resource' => 'application/private',
-                        'result'   => false
+                        'result' => false
                     ),
                     array(
                         'resource' => 'application/secret',
-                        'result'   => true
+                        'result' => true
                     ),
                 )
             )
@@ -62,25 +66,86 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $firewall = new RouteFirewall($rules);
         $mockRbac = $this->getMock('ZfcRbac\Service\Rbac');
         $mockRbac->expects($this->any())
-                 ->method('hasRole')
-                 ->will($this->returnCallback(function($val) {
-            if ($val === array('guest')) {
-                return true;
-            }
+            ->method('hasRole')
+            ->will($this->returnCallback(function ($val) {
+                if ($val === array('guest')) {
+                    return true;
+                }
 
-            return false;
-        }));
+                return false;
+            }));
         $mockRbac->expects($this->any())
-                 ->method('isGranted')
-                 ->will($this->returnCallback(function($val) {
-            if ($val === 'SECRET_PERMISSION') {
-                return true;
-            }
+            ->method('isGranted')
+            ->will($this->returnCallback(function ($val) {
+                if ($val === 'SECRET_PERMISSION') {
+                    return true;
+                }
 
-            return false;
-        }));
+                return false;
+            }));
 
         $firewall->setRbac($mockRbac);
+
+        foreach ($checks as $check) {
+            $this->assertEquals($check['result'], $firewall->isGranted($check['resource']));
+        }
+    }
+
+    public function testRouteFirewallMatchOnlyChildRoutes()
+    {
+        $rules = array(
+            array(
+                'route' => 'user-route',
+                'roles' => 'user'
+            ),
+        );
+
+        $firewall = new RouteFirewall($rules);
+
+        $mockRbac = $this->getMock('ZfcRbac\Service\Rbac');
+        $mockRbac->expects($this->any())
+            ->method('hasRole')
+            ->will($this->returnCallback(function ($val) {
+                if ($val === array('guest')) {
+                    return true;
+                }
+
+                return false;
+            }));
+        $mockRbac->expects($this->any())
+            ->method('isGranted')
+            ->will($this->returnCallback(function ($val) {
+                if ($val === 'SECRET_PERMISSION') {
+                    return true;
+                }
+
+                return false;
+            }));
+
+        $firewall->setRbac($mockRbac);
+
+        $checks = array(
+            array(
+                'resource' => 'user-route',
+                'result' => false
+            ),
+            array(
+                'resource' => 'guest-route',
+                'result' => true
+            ),
+            array(
+                'resource' => 'user-route/foo',
+                'result' => false
+            ),
+            array(
+                'resource' => 'foo/user-route',
+                'result' => true
+            ),
+            array(
+                'resource' => 'myuser-route',
+                'result' => true
+            ),
+        );
 
         foreach ($checks as $check) {
             $this->assertEquals($check['result'], $firewall->isGranted($check['resource']));


### PR DESCRIPTION
I think the reason for using a regex in rules maching is to match child routes.
So we must anchor the regex to the start of the string.

Example : I want to deny access for this parent route `webFoo` :

``` php
'firewalls' => array(
    'ZfcRbac\Firewall\Route' => array(
        array('route' => 'webFoo', 'permissions' => 'myperms'),
    ),
);
```

 It will also match `webFoo/bar` and `webFoo/baz`.
But infortunately, if i don't anchor the regex, it will also match `otherRouter/mywebFoobar`.
