### PR TITLE
Throw exception instead of silently returning

### DIFF
--- a/src/ZfcRbac/Service/AuthorizationService.php
+++ b/src/ZfcRbac/Service/AuthorizationService.php
@@ -111,7 +111,10 @@ class AuthorizationService implements EventManagerAwareInterface
         }
 
         if (!$identity instanceof IdentityInterface) {
-            return [];
+            throw new Exception\RuntimeException(sprintf(
+                'ZfcRbac expects your identity to implement ZfcRbac\Identity\IdentityInterface, "%s" given',
+                is_object($identity) ? get_class($identity) : gettype($identity)
+            ));
         }
 
         $roles = $identity->getRoles();

--- a/tests/ZfcRbacTest/Service/AuthorizationServiceTest.php
+++ b/tests/ZfcRbacTest/Service/AuthorizationServiceTest.php
@@ -285,8 +285,13 @@ class AuthorizationServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['guest'], $result);
     }
 
-    public function testReturnEmptyRolesIfIdentityIsWrongType()
+    public function testThrowExceptionIfIdentityIsWrongType()
     {
+        $this->setExpectedException(
+            'ZfcRbac\Exception\RuntimeException',
+            'ZfcRbac expects your identity to implement ZfcRbac\Identity\IdentityInterface, "stdClass" given'
+        );
+
         $rbac = new Rbac();
 
         $identityProvider = $this->getMock('ZfcRbac\Identity\IdentityProviderInterface');


### PR DESCRIPTION
Someone had a problem because he didn't implement IdentityInterface for his User class. Hard to debug because it silently returns no roles instead of reporting the error.
