### PR TITLE
Check if a permission exist before adding it

### DIFF
--- a/src/ZfcRbac/Permission/PermissionLoaderListener.php
+++ b/src/ZfcRbac/Permission/PermissionLoaderListener.php
@@ -75,7 +75,11 @@ class PermissionLoaderListener extends AbstractListenerAggregate
                     $role = $rbac->getRole($role);
                 }
 
-                $role->addPermission($permission);
+                // We have to check the role does not already contain the permission. This can
+                // happen if you load roles from database, with a ManyToMany associations with Doctrine
+                if (!$role->hasPermission($permission)) {
+                    $role->addPermission($permission);
+                }
             }
         }
     }


### PR DESCRIPTION
ping @BrunoSpy @arakkas

Does this seem logical to you? My idea of separating role loading and permission loading may have not been the best, I can see a lot of useless traversal and object creation here (each "hasPermission" creates a RecursiveIteratorIterator and do an iteration). But for advanced cases I think it makes sense to load them separately.
