### PR TITLE
Issue where identityroles would not get properly converted to strings

### DIFF
--- a/src/ZfcRbac/Collector/RbacCollector.php
+++ b/src/ZfcRbac/Collector/RbacCollector.php
@@ -118,8 +118,19 @@ class RbacCollector implements CollectorInterface, Serializable
      */
     private function collectOptions(ModuleOptions $moduleOptions, AuthorizationService $authorizationService)
     {
+        $identityRoles = $authorizationService->getIdentityRoles();
+
+        $currentRoles = array();
+        foreach ($identityRoles as $role) {
+            if ($role instanceof RoleInterface) {
+                $currentRoles[] = $role->getName();
+            } else {
+                $currentRoles[] = $role;
+            }
+        }
+
         $this->collectedOptions = [
-            'current_roles'     => $authorizationService->getIdentityRoles(),
+            'current_roles'     => $currentRoles,
             'guest_role'        => $moduleOptions->getGuestRole(),
             'protection_policy' => $moduleOptions->getProtectionPolicy()
         ];


### PR DESCRIPTION
Got this error `Object of class Application\Entity\Role could not be converted to string` at https://github.com/ZF-Commons/ZfcRbac/blob/master/view/zend-developer-tools/toolbar/zfc-rbac.phtml#L19
