### PR TITLE
Allowing assertions to work :)

### DIFF
--- a/src/ZfcRbac/Service/AuthorizationService.php
+++ b/src/ZfcRbac/Service/AuthorizationService.php
@@ -70,9 +70,13 @@ class AuthorizationService
             $identity = $this->roleService->getIdentity();
 
             if (is_callable($assertion)) {
-                return (bool) $assertion($identity);
+                if (true === $assertion($identity)) {
+                    return true;
+                }
             } elseif ($assertion instanceof AssertionInterface) {
-                return (bool) $assertion->assert($identity);
+                if (true === $assertion->assert($identity)) {
+                    return true;
+                }
             } else {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Assertions must be callable or implement ZfcRbac\Assertion\AssertionInterface, "%s" given',


### PR DESCRIPTION
The Assertions - as far as I understand - should only return the true case, if anything. If an assertion is `false`, `isGranted()` should still be able to return `true` if the permission is granted from the role. This change now fixes things, but we really need them unit tests :P #136
