### PR TITLE
ControllerGuard now supports assertion

### DIFF
--- a/src/ZfcRbac/Guard/AbstractAssertionGuard.php
+++ b/src/ZfcRbac/Guard/AbstractAssertionGuard.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+namespace ZfcRbac\Guard;
+
+use ZfcRbac\Assertion\AssertionInterface;
+use ZfcRbac\Exception;
+
+abstract class AbstractAssertionGuard extends AbstractGuard
+{
+
+    /**
+     * @param  callable|AssertionInterface $assertion
+     * @return bool
+     * @throws Exception\InvalidArgumentException
+     */
+    protected function assert($assertion)
+    {
+        $identity = $this->roleService->getIdentity();
+
+        if (is_callable($assertion)) {
+            return $assertion($identity);
+        } elseif ($assertion instanceof AssertionInterface) {
+            return $assertion->assert($identity);
+        }
+
+        throw new Exception\InvalidArgumentException(sprintf(
+            'Assertions must be callable or implement ZfcRbac\Assertion\AssertionInterface, "%s" given',
+            is_object($assertion) ? get_class($assertion) : gettype($assertion)
+        ));
+    }
+}

--- a/tests/ZfcRbacTest/Guard/ControllerGuardTest.php
+++ b/tests/ZfcRbacTest/Guard/ControllerGuardTest.php
@@ -63,9 +63,24 @@ class ControllerGuardTest extends \PHPUnit_Framework_TestCase
                     ])
                 ],
                 'expected' => [
-                    'mycontroller'  => [0 => ['role1']],
-                    'mycontroller2' => [0 => ['role2', 'role3']],
-                    'mycontroller3' => [0 => ['role4']]
+                    'mycontroller'  => [
+                        [
+                            'roles' => ['role1'],
+                            'assertion' => false
+                        ]
+                    ],
+                    'mycontroller2' => [
+                        [
+                            'roles' => ['role2', 'role3'],
+                            'assertion' => false
+                        ]
+                    ],
+                    'mycontroller3' => [
+                        [
+                            'roles' => ['role4'],
+                            'assertion' => false
+                        ]
+                    ]
                 ]
             ],
 
@@ -90,14 +105,23 @@ class ControllerGuardTest extends \PHPUnit_Framework_TestCase
                 ],
                 'expected' => [
                     'mycontroller'  => [
-                        'delete' => ['role1']
+                        'delete' => [
+                            'roles' => ['role1'],
+                            'assertion' => false
+                        ]
                     ],
                     'mycontroller2'  => [
-                        'delete' => ['role2']
+                        'delete' => [
+                            'roles' => ['role2'],
+                            'assertion' => false
+                        ]
                     ],
                     'mycontroller3'  => [
-                        'delete' => ['role3']
-                    ],
+                        'delete' => [
+                            'roles' => ['role3'],
+                            'assertion' => false
+                        ]
+                    ]
                 ]
             ],
 
@@ -117,12 +141,24 @@ class ControllerGuardTest extends \PHPUnit_Framework_TestCase
                 ],
                 'expected' => [
                     'mycontroller'  => [
-                        'edit'   => ['role1'],
-                        'delete' => ['role1']
+                        'edit'   => [
+                            'roles' => ['role1'],
+                            'assertion' => false
+                        ],
+                        'delete' => [
+                            'roles' => ['role1'],
+                            'assertion' => false
+                        ]
                     ],
                     'mycontroller2'  => [
-                        'edit'   => ['role2'],
-                        'delete' => ['role2']
+                        'edit'   => [
+                            'roles' => ['role2'],
+                            'assertion' => false
+                        ],
+                        'delete' => [
+                            'roles' => ['role2'],
+                            'assertion' => false
+                        ]
                     ]
                 ]
             ],
@@ -143,8 +179,14 @@ class ControllerGuardTest extends \PHPUnit_Framework_TestCase
                 ],
                 'expected' => [
                     'mycontroller'  => [
-                        'edit' => ['role1'],
-                        0      => ['role2']
+                        'edit' =>  [
+                            'roles' => ['role1'],
+                            'assertion' => false
+                        ],
+                        0      =>  [
+                            'roles' => ['role2'],
+                            'assertion' => false
+                        ]
                     ]
                 ]
             ]
@@ -392,6 +434,46 @@ class ControllerGuardTest extends \PHPUnit_Framework_TestCase
                 'identityRole' => 'admin',
                 'isGranted'    => true,
                 'policy'       => GuardInterface::POLICY_DENY
+            ],
+            
+            // Test simple guard with assertions
+            [
+                'rules' => [
+                    [
+                        'controller' => 'BlogController',
+                        'roles'      => 'admin',
+                        'assertion'  => function ($identity) {
+                            return true;
+                        }
+                    ]
+                ],
+                'controller'   => 'BlogController',
+                'action'       => 'edit',
+                'rolesConfig'  => [
+                    'admin'
+                ],
+                'identityRole' => 'admin',
+                'isGranted'    => true,
+                'policy'       => GuardInterface::POLICY_ALLOW
+            ],
+            [
+                'rules' => [
+                    [
+                        'controller' => 'BlogController',
+                        'roles'      => 'admin',
+                        'assertion'  => function ($identity) {
+                            return false;
+                        }
+                    ]
+                ],
+                'controller'   => 'BlogController',
+                'action'       => 'edit',
+                'rolesConfig'  => [
+                    'admin'
+                ],
+                'identityRole' => 'admin',
+                'isGranted'    => false,
+                'policy'       => GuardInterface::POLICY_ALLOW
             ],
         ];
     }


### PR DESCRIPTION
Hi,

since I needed this myself I thought this might be a good addition to guards in general. I've only implemented this for the ControllerGuard yet, to see if this is a desired feature.

The idea is very simple and much like the `isGranted($permission, $assertion)`, only that it works for guards as well. An example config is:

```
[
    'controller' => 'BlogController',
    'roles'      => 'admin',
    'assertion'  => function ($identity) {
        return false;
    }
]
```

Of course, this works with classes implementing the `AssertionInterface` as well.

Tests have already been added and updated.
