### PR TITLE
Add 'context' argument to AssertionInterface

### DIFF
--- a/src/ZfcRbac/Assertion/AssertionInterface.php
+++ b/src/ZfcRbac/Assertion/AssertionInterface.php
@@ -37,5 +37,5 @@ interface AssertionInterface
      * @param  mixed                $context
      * @return bool
      */
-    public function assert(AuthorizationService $authorization);
+    public function assert(AuthorizationService $authorization, $context = null);
 }


### PR DESCRIPTION
The declaration of the method 'assert' in the AssertionInterface does not contain the second argument 'context'. However, it exist everywhere: in the documentation, in tests, in @phpdok-block.
Its absence is confusing.
