### PR TITLE
Added AuthorizationResult

### DIFF
--- a/src/ZfcRbac/Result/AuthorizationResult.php
+++ b/src/ZfcRbac/Result/AuthorizationResult.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+namespace ZfcRbac\Result;
+
+use Rbac\Role\RoleInterface;
+use ZfcRbac\Identity\IdentityInterface;
+
+/**
+ * The Result the AuthorizationService returns
+ *
+ * @author  Aeneas Rekkas
+ * @licence MIT
+ */
+class AuthorizationResult
+{
+    /**
+     * @var string
+     */
+    protected $permission;
+
+    /**
+     * @var IdentityInterface|null
+     */
+    protected $identity;
+
+    /**
+     * @var RoleInterface[]
+     */
+    protected $roles = [];
+
+    /**
+     * @param null|IdentityInterface $identity
+     */
+    public function setIdentity($identity)
+    {
+        $this->identity = $identity;
+    }
+
+    /**
+     * @return null|IdentityInterface
+     */
+    public function getIdentity()
+    {
+        return $this->identity;
+    }
+
+    /**
+     * @param string $permission
+     */
+    public function setPermission($permission)
+    {
+        $this->permission = $permission;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPermission()
+    {
+        return $this->permission;
+    }
+
+    /**
+     * @param RoleInterface[] $roles
+     */
+    public function setRoles(array $roles)
+    {
+        $this->roles = $roles;
+    }
+
+    /**
+     * @return RoleInterface[]
+     */
+    public function getRoles()
+    {
+        return $this->roles;
+    }
+}

--- a/src/ZfcRbac/Service/AuthorizationService.php
+++ b/src/ZfcRbac/Service/AuthorizationService.php
@@ -24,6 +24,7 @@ use ZfcRbac\Assertion\AssertionPluginManager;
 use ZfcRbac\Assertion\AssertionInterface;
 use ZfcRbac\Exception;
 use ZfcRbac\Identity\IdentityInterface;
+use ZfcRbac\Result\AuthorizationResult;
 
 /**
  * Authorization service is a simple service that internally uses Rbac to check if identity is
@@ -55,6 +56,11 @@ class AuthorizationService
     protected $assertions = [];
 
     /**
+     * @var AuthorizationResult
+     */
+    protected $authorizationResult;
+
+    /**
      * Constructor
      *
      * @param Rbac                   $rbac
@@ -66,6 +72,7 @@ class AuthorizationService
         $this->rbac                   = $rbac;
         $this->roleService            = $roleService;
         $this->assertionPluginManager = $assertionPluginManager;
+        $this->authorizationResult    = new AuthorizationResult();
     }
 
     /**
@@ -89,6 +96,14 @@ class AuthorizationService
     public function setAssertions(array $assertions)
     {
         $this->assertions = $assertions;
+    }
+
+    /**
+     * @return AuthorizationResult
+     */
+    public function getAuthorizationResult()
+    {
+        return $this->authorizationResult;
     }
 
     /**
@@ -122,6 +137,10 @@ class AuthorizationService
     public function isGranted($permission, $context = null)
     {
         $roles = $this->roleService->getIdentityRoles();
+
+        $this->authorizationResult->setPermission($permission);
+        $this->authorizationResult->setIdentity($this->getIdentity());
+        $this->authorizationResult->setRoles($roles);
 
         if (empty($roles)) {
             return false;


### PR DESCRIPTION
This is related to #180

I know that this PR creates some overhead, because the AuthorizationService actually implements already `getIdentity` but the permission's name as well as the identities roles are really really really important for many Assertions and since I do not want to break BC, I couldn't find another way. Also it's maybe not that useless, since we can now do:

``` php
if($as->isGranted('something')){
   $result = $as->getAuthorizationResult();
   // Do something
}
```

This is explicitly written in that matter, that we do not need to tag 3.0
