### PR TITLE
Check for method getRoles

### DIFF
--- a/src/ZfcRbac/Service/RoleService.php
+++ b/src/ZfcRbac/Service/RoleService.php
@@ -116,7 +116,7 @@ class RoleService
             return $this->convertRoles([$this->guestRole]);
         }
 
-        if (!$identity instanceof IdentityInterface) {
+        if (!$identity instanceof IdentityInterface && !method_exists($identity, 'getRoles')) {
             throw new Exception\RuntimeException(sprintf(
                 'ZfcRbac expects your identity to implement ZfcRbac\Identity\IdentityInterface, "%s" given',
                 is_object($identity) ? get_class($identity) : gettype($identity)


### PR DESCRIPTION
If the method exists in the base identity, isn't it overkill to be obliged to override it just to implement an interface.
