### PR TITLE
Fixed documentation Error regarding `role_provider_manager`

### DIFF
--- a/docs/03. Role providers.md
+++ b/docs/03. Role providers.md
@@ -169,10 +169,12 @@ Then, you need to add it to the role provider manager:
 
 ```php
 return [
-    'role_provider_manager' => [
-        'factories' => [
-            'Application\Role\CustomRoleProvider' => 'Application\Factory\CustomRoleProviderFactory'
-        ]
+    'zfc_rbac' => [
+        'role_provider_manager' => [
+            'factories' => [
+                'Application\Role\CustomRoleProvider' => 'Application\Factory\CustomRoleProviderFactory'
+            ]
+        ]    
     ]
 ];
 ```


### PR DESCRIPTION
Viewing this [link](https://github.com/ZF-Commons/zfc-rbac/blob/master/src/ZfcRbac/Factory/RoleProviderPluginManagerFactory.php#L40), I thought this was just a simple error in the documentation!
