### PR TITLE
Hotfix for #194

### DIFF
--- a/src/ZfcRbac/Role/ObjectRepositoryRoleProvider.php
+++ b/src/ZfcRbac/Role/ObjectRepositoryRoleProvider.php
@@ -57,6 +57,16 @@ class ObjectRepositoryRoleProvider implements RoleProviderInterface
     }
 
     /**
+     * Clears the role cache
+     *
+     * @return void
+     */
+    public function clearRoleCache()
+    {
+        $this->roleCache = [];
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getRoles(array $roleNames)

--- a/tests/ZfcRbacTest/Role/ObjectRepositoryRoleProviderTest.php
+++ b/tests/ZfcRbacTest/Role/ObjectRepositoryRoleProviderTest.php
@@ -124,6 +124,20 @@ class ObjectRepositoryRoleProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result, $provider->getRoles(['member']));
     }
 
+    public function testClearRoleCache()
+    {
+        $objectRepository = $this->getMock('Doctrine\ORM\EntityRepository', ['findBy'], [], '', false);
+        $memberRole       = new FlatRole('member');
+        $provider         = new ObjectRepositoryRoleProvider($objectRepository, 'name');
+        $result           = [$memberRole];
+
+        $objectRepository->expects($this->exactly(2))->method('findBy')->will($this->returnValue($result));
+
+        $this->assertEquals($result, $provider->getRoles(['member']));
+        $provider->clearRoleCache();
+        $this->assertEquals($result, $provider->getRoles(['member']));
+    }
+
     public function testThrowExceptionIfAskedRoleIsNotFound()
     {
         $this->serviceManager = ServiceManagerFactory::getServiceManager();


### PR DESCRIPTION
I guess there are more sophisticated ways for this. Maybe we could even consider to make this optional (although I don't really think that that's neccessary) but those few lines reduced the queries by a tenth in our application, so I guess this is really necessary.
