### PR TITLE
Correct interface not accepting $context param.

### DIFF
--- a/src/ZfcRbac/Assertion/AssertionInterface.php
+++ b/src/ZfcRbac/Assertion/AssertionInterface.php
@@ -39,5 +39,5 @@ interface AssertionInterface
      * @param  mixed                $context
      * @return bool
      */
-    public function assert(AuthorizationService $authorizationService);
+    public function assert(AuthorizationService $authorizationService, $context);
 }


### PR DESCRIPTION
This appears to be a bug, the assertion interface does not accept a context, although the docblock says it does.
