### PR TITLE
Added namespaces and annotations to Cookbook for using ZfcRbac with Doctrine ORM.

### DIFF
--- a/docs/07. Cookbook.md
+++ b/docs/07. Cookbook.md
@@ -468,7 +468,7 @@ use Doctrine\Common\Collections\Collection;
  * @ORM\Table(name="user")
  */
 class User extends ZfcUserEntity implements IdentityInterface
-    {
+{
     /**
      * @var Collection
      * @ORM\ManyToMany(targetEntity="HierarchicalRole")


### PR DESCRIPTION
The `use` statements should be complete.

Is extending `ZfcUserEntity` correct too?

In my Application I had to add the `Entity` annotations otherwise I got this error:
**Class "Application\Entity\User" sub class of "ZfcUser\Entity\User" is not a valid entity or mapped super class.**

Mentioned in issue https://github.com/ZF-Commons/zfc-rbac/issues/17 .
