### PR TITLE
Re-add removed context parameter

### DIFF
--- a/src/ZfcRbac/Assertion/AssertionInterface.php
+++ b/src/ZfcRbac/Assertion/AssertionInterface.php
@@ -39,5 +39,5 @@ interface AssertionInterface
      * @param  mixed                $context
      * @return bool
      */
-    public function assert(AuthorizationService $authorizationService);
+    public function assert(AuthorizationService $authorizationService, $context = null);
 }


### PR DESCRIPTION
Context parameter was removed from the assert interface, but is still required by the AuthenticationService.
