### PR TITLE
Conditions for Guards

### DIFF
--- a/docs/04. Guards.md
+++ b/docs/04. Guards.md
@@ -177,7 +177,7 @@ return [
         'guards' => [
             'ZfcRbac\Guard\RoutePermissionsGuard' => [
                 'admin*' => ['admin'],
-                'post/manage'   =>
+                'post/manage' => ['post.update', 'post.delete']
             ]
         ]
     ]

--- a/docs/04. Guards.md
+++ b/docs/04. Guards.md
@@ -177,17 +177,34 @@ return [
         'guards' => [
             'ZfcRbac\Guard\RoutePermissionsGuard' => [
                 'admin*' => ['admin'],
-                'post/manage'   => ['post.update', 'post.delete']
+                'post/manage'   =>
             ]
         ]
     ]
 ];
 ```
 
-> All permissions in a rule must be matched (it is an AND condition).
+> By default, all permissions in a rule must be matched (an AND condition).
 
 In the previous example, one must have ```post.update``` **AND** ```post.delete``` permissions
-to access the ```post/manage``` route.
+to access the ```post/manage``` route. You can also specify an OR condition like so:
+
+```php
+use ZfcRbac\Guard\GuardInterface;
+
+return [
+    'zfc_rbac' => [
+        'guards' => [
+            'ZfcRbac\Guard\RoutePermissionsGuard' => [
+                'post/manage'   => [
+                    'permissions' => ['post.update', 'post.delete'],
+                    'condition'   => GuardInterface::CONDITION_OR
+                ]
+            ]
+        ]
+    ]
+];
+```
 
 > Permissions are linked to roles, not to users
 

--- a/src/ZfcRbac/Guard/GuardInterface.php
+++ b/src/ZfcRbac/Guard/GuardInterface.php
@@ -48,6 +48,12 @@ interface GuardInterface extends ListenerAggregateInterface
     const POLICY_ALLOW = 'allow';
 
     /**
+     * Condition constants
+     */
+    const CONDITION_OR  = 'OR';
+    const CONDITION_AND = 'AND';
+
+    /**
      * @param  MvcEvent $event
      * @return bool
      */

--- a/src/ZfcRbac/Guard/RoutePermissionsGuard.php
+++ b/src/ZfcRbac/Guard/RoutePermissionsGuard.php
@@ -18,7 +18,6 @@
 namespace ZfcRbac\Guard;
 
 use Zend\Mvc\MvcEvent;
-use ZfcRbac\Exception;
 use ZfcRbac\Service\AuthorizationServiceInterface;
 
 /**
@@ -101,10 +100,19 @@ class RoutePermissionsGuard extends AbstractGuard
             return true;
         }
 
-        foreach ($allowedPermissions as $permission) {
-            if (!$this->authorizationService->isGranted($permission)) {
+        $permissions = isset($allowedPermissions['permissions']) ? $allowedPermissions['permissions'] : $allowedPermissions;
+        $condition   = isset($allowedPermissions['condition']) ? $allowedPermissions['condition'] : GuardInterface::CONDITION_AND;
+
+        foreach ($permissions as $permission) {
+            if ($condition == GuardInterface::CONDITION_OR && !$this->authorizationService->isGranted($permission)) {
+                return true;
+            } elseif ($condition == GuardInterface::CONDITION_AND && !$this->authorizationService->isGranted($permission)) {
                 return false;
             }
+        }
+
+        if ($condition == GuardInterface::CONDITION_OR) {
+            return false;
         }
 
         return true;

--- a/src/ZfcRbac/Guard/RoutePermissionsGuard.php
+++ b/src/ZfcRbac/Guard/RoutePermissionsGuard.php
@@ -108,22 +108,29 @@ class RoutePermissionsGuard extends AbstractGuard
             ? $allowedPermissions['condition']
             : GuardInterface::CONDITION_AND;
 
-        foreach ($permissions as $permission) {
-            if ($condition === GuardInterface::CONDITION_OR
-                && $this->authorizationService->isGranted($permission)
-            ) {
-                return true;
-            } elseif ($condition === GuardInterface::CONDITION_AND
-                      && !$this->authorizationService->isGranted($permission)
-            ) {
-                return false;
+        if (GuardInterface::CONDITION_AND === $condition) {
+            foreach ($permissions as $permission) {
+                if (!$this->authorizationService->isGranted($permission)) {
+                    return false;
+                }
             }
-        }
-
-        if ($condition === GuardInterface::CONDITION_OR) {
+        
+            return true;
+        }    
+        
+        if (GuardInterface::CONDITION_OR === $condition) {
+            foreach ($permissions as $permission) {
+                if ($this->authorizationService->isGranted($permission)) {
+                    return true;
+                }
+            }
+        
             return false;
-        }
-
-        return true;
+        }    
+        
+        throw new InvalidArgumentException(sprintf(
+            'Condition must be either "AND" or "OR", %s given',
+            is_object($condition) ? get_class($condition) : gettype($condition)
+        ));
     }
 }

--- a/src/ZfcRbac/Guard/RoutePermissionsGuard.php
+++ b/src/ZfcRbac/Guard/RoutePermissionsGuard.php
@@ -114,20 +114,20 @@ class RoutePermissionsGuard extends AbstractGuard
                     return false;
                 }
             }
-        
+
             return true;
-        }    
-        
+        }
+
         if (GuardInterface::CONDITION_OR === $condition) {
             foreach ($permissions as $permission) {
                 if ($this->authorizationService->isGranted($permission)) {
                     return true;
                 }
             }
-        
+
             return false;
-        }    
-        
+        }
+
         throw new InvalidArgumentException(sprintf(
             'Condition must be either "AND" or "OR", %s given',
             is_object($condition) ? get_class($condition) : gettype($condition)

--- a/src/ZfcRbac/Guard/RoutePermissionsGuard.php
+++ b/src/ZfcRbac/Guard/RoutePermissionsGuard.php
@@ -104,7 +104,7 @@ class RoutePermissionsGuard extends AbstractGuard
         $condition   = isset($allowedPermissions['condition']) ? $allowedPermissions['condition'] : GuardInterface::CONDITION_AND;
 
         foreach ($permissions as $permission) {
-            if ($condition == GuardInterface::CONDITION_OR && !$this->authorizationService->isGranted($permission)) {
+            if ($condition == GuardInterface::CONDITION_OR && $this->authorizationService->isGranted($permission)) {
                 return true;
             } elseif ($condition == GuardInterface::CONDITION_AND && !$this->authorizationService->isGranted($permission)) {
                 return false;

--- a/src/ZfcRbac/Guard/RoutePermissionsGuard.php
+++ b/src/ZfcRbac/Guard/RoutePermissionsGuard.php
@@ -104,14 +104,14 @@ class RoutePermissionsGuard extends AbstractGuard
         $condition   = isset($allowedPermissions['condition']) ? $allowedPermissions['condition'] : GuardInterface::CONDITION_AND;
 
         foreach ($permissions as $permission) {
-            if ($condition == GuardInterface::CONDITION_OR && $this->authorizationService->isGranted($permission)) {
+            if ($condition === GuardInterface::CONDITION_OR && $this->authorizationService->isGranted($permission)) {
                 return true;
-            } elseif ($condition == GuardInterface::CONDITION_AND && !$this->authorizationService->isGranted($permission)) {
+            } elseif ($condition === GuardInterface::CONDITION_AND && !$this->authorizationService->isGranted($permission)) {
                 return false;
             }
         }
 
-        if ($condition == GuardInterface::CONDITION_OR) {
+        if ($condition === GuardInterface::CONDITION_OR) {
             return false;
         }
 

--- a/src/ZfcRbac/Guard/RoutePermissionsGuard.php
+++ b/src/ZfcRbac/Guard/RoutePermissionsGuard.php
@@ -100,13 +100,22 @@ class RoutePermissionsGuard extends AbstractGuard
             return true;
         }
 
-        $permissions = isset($allowedPermissions['permissions']) ? $allowedPermissions['permissions'] : $allowedPermissions;
-        $condition   = isset($allowedPermissions['condition']) ? $allowedPermissions['condition'] : GuardInterface::CONDITION_AND;
+        $permissions = isset($allowedPermissions['permissions'])
+            ? $allowedPermissions['permissions']
+            : $allowedPermissions;
+
+        $condition   = isset($allowedPermissions['condition'])
+            ? $allowedPermissions['condition']
+            : GuardInterface::CONDITION_AND;
 
         foreach ($permissions as $permission) {
-            if ($condition === GuardInterface::CONDITION_OR && $this->authorizationService->isGranted($permission)) {
+            if ($condition === GuardInterface::CONDITION_OR
+                && $this->authorizationService->isGranted($permission)
+            ) {
                 return true;
-            } elseif ($condition === GuardInterface::CONDITION_AND && !$this->authorizationService->isGranted($permission)) {
+            } elseif ($condition === GuardInterface::CONDITION_AND
+                      && !$this->authorizationService->isGranted($permission)
+            ) {
                 return false;
             }
         }

--- a/tests/ZfcRbacTest/Guard/RoutePermissionsGuardTest.php
+++ b/tests/ZfcRbacTest/Guard/RoutePermissionsGuardTest.php
@@ -332,8 +332,18 @@ class RoutePermissionsGuardTest extends \PHPUnit_Framework_TestCase
                     'condition'   => GuardInterface::CONDITION_OR
                 ]],
                 'matchedRouteName'    => 'route',
-                'identityPermissions' => [['post.edit', null, false]],
+                'identityPermissions' => [['post.edit', null, true]],
                 'isGranted'           => true,
+                'policy'              => GuardInterface::POLICY_DENY
+            ],
+            [
+                'rules'               => ['route' => [
+                    'permissions' => ['post.edit', 'post.read'],
+                    'condition'   => GuardInterface::CONDITION_AND
+                ]],
+                'matchedRouteName'    => 'route',
+                'identityPermissions' => [['post.edit', null, true]],
+                'isGranted'           => false,
                 'policy'              => GuardInterface::POLICY_DENY
             ]
         ];

--- a/tests/ZfcRbacTest/Guard/RoutePermissionsGuardTest.php
+++ b/tests/ZfcRbacTest/Guard/RoutePermissionsGuardTest.php
@@ -326,6 +326,16 @@ class RoutePermissionsGuardTest extends \PHPUnit_Framework_TestCase
                 'isGranted'           => true,
                 'policy'              => GuardInterface::POLICY_DENY
             ],
+            [
+                'rules'               => ['route' => [
+                    'permissions' => ['post.edit', 'post.read'],
+                    'condition'   => GuardInterface::CONDITION_OR
+                ]],
+                'matchedRouteName'    => 'route',
+                'identityPermissions' => [['post.edit', null, false]],
+                'isGranted'           => true,
+                'policy'              => GuardInterface::POLICY_DENY
+            ]
         ];
     }
 


### PR DESCRIPTION
See #262.

So far this only applies to the RoutePermissionGuard as a proof of concept.

It's a shame that this guard specifically was created with an AND default whereas an OR would have made more sense (like the RouteGuard).