### PR TITLE
changed logic for assertion part

### DIFF
--- a/src/ZfcRbac/Service/AuthorizationService.php
+++ b/src/ZfcRbac/Service/AuthorizationService.php
@@ -123,19 +123,15 @@ class AuthorizationService implements AuthorizationServiceInterface
     {
         $roles = $this->roleService->getIdentityRoles();
 
-        if (empty($roles)) {
-            return false;
-        }
-
-        if (!$this->rbac->isGranted($roles, $permission)) {
-            return false;
+        if (!empty($roles) && $this->rbac->isGranted($roles, $permission)) {
+            return true;
         }
 
         if ($this->hasAssertion($permission)) {
             return $this->assert($this->assertions[(string) $permission], $context);
         }
 
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
old logic:
1. if identity hasn't roles - no checks for assertions. (why?). return false (no granted)
2. if identity roles don't have a permission - no checks for assertions. (why? WHY?) return false (no granted)
3. checks assertion - no comments, it's ok
4. return true, hmm... ok

new logic:
1. if identity has one or more roles and any role has permission - return true
2. if has assertion - check
3. return false - (no roles with permission and no assertions)
