### PR TITLE
Methode assert declaration raise a fatal error.

### DIFF
--- a/src/ZfcRbac/Assertion/AssertionInterface.php
+++ b/src/ZfcRbac/Assertion/AssertionInterface.php
@@ -39,5 +39,5 @@ interface AssertionInterface
      * @param  mixed                $context
      * @return bool
      */
-    public function assert(AuthorizationService $authorizationService, $context );
+    public function assert(AuthorizationService $authorizationService, $context);
 }


### PR DESCRIPTION
Methode assert declaration raise a fatal error in php5.5 Fatal error strict standard $context param must apprear in the function declaration.

I already explain that o Daniel via email.

Thank you
