### PR TITLE
Replace ObjectManager with Selectable

### DIFF
--- a/src/ZfcRbac/Role/ObjectRepositoryRoleProvider.php
+++ b/src/ZfcRbac/Role/ObjectRepositoryRoleProvider.php
@@ -18,11 +18,12 @@
 
 namespace ZfcRbac\Role;
 
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Selectable;
 use ZfcRbac\Exception\RoleNotFoundException;
 
 /**
- * Role provider that uses Doctrine object repository to fetch roles
+ * Role provider that uses Doctrine selectable to fetch roles
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
  * @licence MIT
@@ -30,9 +31,9 @@ use ZfcRbac\Exception\RoleNotFoundException;
 class ObjectRepositoryRoleProvider implements RoleProviderInterface
 {
     /**
-     * @var ObjectRepository
+     * @var Selectable
      */
-    private $objectRepository;
+    private $selectable;
 
     /**
      * @var string
@@ -47,12 +48,12 @@ class ObjectRepositoryRoleProvider implements RoleProviderInterface
     /**
      * Constructor
      *
-     * @param ObjectRepository $objectRepository
-     * @param string           $roleNameProperty
+     * @param Selectable $selectable
+     * @param string     $roleNameProperty
      */
-    public function __construct(ObjectRepository $objectRepository, $roleNameProperty)
+    public function __construct(Selectable $selectable, $roleNameProperty)
     {
-        $this->objectRepository = $objectRepository;
+        $this->selectable       = $selectable;
         $this->roleNameProperty = $roleNameProperty;
     }
 
@@ -77,7 +78,10 @@ class ObjectRepositoryRoleProvider implements RoleProviderInterface
             return $this->roleCache[$key];
         }
 
-        $roles = $this->objectRepository->findBy([$this->roleNameProperty => $roleNames]);
+        $criteria = Criteria::create();
+        $criteria->where($criteria->expr()->in($this->roleNameProperty, $roleNames));
+
+        $roles = $this->selectable->matching($criteria);
 
         // We allow more roles to be loaded than asked (although this should not happen because
         // role name should have a UNIQUE constraint in database... but just in case ;))

--- a/src/ZfcRbac/Role/ObjectRepositoryRoleProvider.php
+++ b/src/ZfcRbac/Role/ObjectRepositoryRoleProvider.php
@@ -81,7 +81,7 @@ class ObjectRepositoryRoleProvider implements RoleProviderInterface
         $criteria = Criteria::create();
         $criteria->where($criteria->expr()->in($this->roleNameProperty, $roleNames));
 
-        $roles = $this->selectable->matching($criteria);
+        $roles = $this->selectable->matching($criteria)->toArray();
 
         // We allow more roles to be loaded than asked (although this should not happen because
         // role name should have a UNIQUE constraint in database... but just in case ;))


### PR DESCRIPTION
```findBy(['property' => []])``` is a feature available in ```EntityManager``` only. Since you're typehinting ```ObjectManager``` instead of ```EntityManager```, is expected that this will work if you provide a MongoDB ODM ```DocumentManager```, which unfortunately does not happen given the lack of support for values in arrays.

That said, i propose to use ```Selectable``` instead of ```ObjectManager```, so it will be possible to use even a ```Role``` ```Collection``` to retrieve the Roles.

This might seem very strange not to consider this a BC Break, but since you're typehinting ```ObjectManager``` the expected behavior is already to work with any manager, and if this is not happening, i would consider this more a bugfix than a bc break. Also, the only possible working setting is ```EntityManager```, which is a ```Selectable``` instance, so it will be perfectly compatible with any previous implementation.


