### PR TITLE
collectPermissions check if getPermissions method exists

### DIFF
--- a/src/ZfcRbac/Collector/RbacCollector.php
+++ b/src/ZfcRbac/Collector/RbacCollector.php
@@ -181,12 +181,17 @@ class RbacCollector implements CollectorInterface, Serializable
      */
     private function collectPermissions(RoleInterface $role)
     {
-        // Gather the permissions for the given role. We have to use reflection as
-        // the RoleInterface does not have "getPermissions" method
-        $reflectionProperty = new ReflectionProperty($role, 'permissions');
-        $reflectionProperty->setAccessible(true);
+        if (method_exists($role, 'getPermissions')) {
+            $permissions = $role->getPermissions();
+        } else {
 
-        $permissions = $reflectionProperty->getValue($role);
+            // Gather the permissions for the given role. We have to use reflection as
+            // the RoleInterface does not have "getPermissions" method
+            $reflectionProperty = new ReflectionProperty($role, 'permissions');
+            $reflectionProperty->setAccessible(true);
+
+            $permissions = $reflectionProperty->getValue($role);
+        }
 
         if ($permissions instanceof Traversable) {
             $permissions = iterator_to_array($permissions);

--- a/tests/ZfcRbacTest/Asset/MockRoleWithPermissionMethod.php
+++ b/tests/ZfcRbacTest/Asset/MockRoleWithPermissionMethod.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZfcRbacTest\Asset;
+
+use Rbac\Role\RoleInterface;
+
+class MockRoleWithPermissionMethod implements RoleInterface
+{
+    public function getPermissions()
+    {
+        return ['permission-method-a', 'permission-method-b'];
+    }
+
+    public function getName()
+    {
+        return 'role-with-permission-method';
+    }
+    public function hasPermission($permission)
+    {
+        return false;
+    }
+}

--- a/tests/ZfcRbacTest/Asset/MockRoleWithPermissionProperty.php
+++ b/tests/ZfcRbacTest/Asset/MockRoleWithPermissionProperty.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ZfcRbacTest\Asset;
+
+use Rbac\Role\RoleInterface;
+
+class MockRoleWithPermissionProperty implements RoleInterface
+{
+    private $permissions = ['permission-property-a', 'permission-property-b'];
+
+    public function getName()
+    {
+        return 'role-with-permission-property';
+    }
+    public function hasPermission($permission)
+    {
+        return false;
+    }
+}

--- a/tests/ZfcRbacTest/Collector/RbacCollectorTest.php
+++ b/tests/ZfcRbacTest/Collector/RbacCollectorTest.php
@@ -29,6 +29,8 @@ use ZfcRbac\Role\InMemoryRoleProvider;
 use ZfcRbac\Role\RoleProviderInterface;
 use ZfcRbac\Service\RoleService;
 use Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy;
+use ZfcRbacTest\Asset\MockRoleWithPermissionMethod;
+use ZfcRbacTest\Asset\MockRoleWithPermissionProperty;
 
 /**
  * @covers \ZfcRbac\Collector\RbacCollector
@@ -269,35 +271,4 @@ class RbacCollectorTest extends \PHPUnit_Framework_TestCase
         return $collector->getCollection();
     }
 
-}
-
-class MockRoleWithPermissionProperty implements RoleInterface
-{
-    private $permissions = ['permission-property-a', 'permission-property-b'];
-
-    public function getName()
-    {
-        return 'role-with-permission-property';
-    }
-    public function hasPermission($permission)
-    {
-        return false;
-    }
-}
-
-class MockRoleWithPermissionMethod implements RoleInterface
-{
-    public function getPermissions()
-    {
-        return ['permission-method-a', 'permission-method-b'];
-    }
-
-    public function getName()
-    {
-        return 'role-with-permission-method';
-    }
-    public function hasPermission($permission)
-    {
-        return false;
-    }
 }

--- a/tests/ZfcRbacTest/Collector/RbacCollectorTest.php
+++ b/tests/ZfcRbacTest/Collector/RbacCollectorTest.php
@@ -246,7 +246,7 @@ class RbacCollectorTest extends \PHPUnit_Framework_TestCase
             ->method('getIdentity')
             ->will($this->returnValue($identity));
 
-        $roleProvider = $this->getMock(RoleProviderInterface::class);
+        $roleProvider = $this->getMock('ZfcRbac\Role\RoleProviderInterface');
 
         $roleService = new RoleService($identityProvider,
             $roleProvider,

--- a/tests/ZfcRbacTest/Collector/RbacCollectorTest.php
+++ b/tests/ZfcRbacTest/Collector/RbacCollectorTest.php
@@ -18,6 +18,7 @@
 
 namespace ZfcRbacTest\Collector;
 
+use Rbac\Role\RoleInterface;
 use Zend\Mvc\MvcEvent;
 use Zend\Permissions\Rbac\Rbac;
 use Zend\Permissions\Rbac\Role;
@@ -25,6 +26,7 @@ use ZfcRbac\Collector\RbacCollector;
 use ZfcRbac\Guard\GuardInterface;
 use ZfcRbac\Options\ModuleOptions;
 use ZfcRbac\Role\InMemoryRoleProvider;
+use ZfcRbac\Role\RoleProviderInterface;
 use ZfcRbac\Service\RoleService;
 use Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy;
 
@@ -175,5 +177,127 @@ class RbacCollectorTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->assertEquals($expectedCollection, $collection);
+    }
+
+    /**
+     * Tests the collectPermissions method when the role has a $permissions Property
+     */
+    public function testCollectPermissionsProperty()
+    {
+        $expectedCollection = [
+            'guards' => [],
+            'roles'  => ['role-with-permission-property'],
+            'permissions' => [
+                'role-with-permission-property' => ['permission-property-a', 'permission-property-b'],
+            ],
+            'options' => [
+                'guest_role' => 'guest',
+                'protection_policy' => GuardInterface::POLICY_ALLOW,
+            ],
+        ];
+
+        $collection = $this->collectPermissionsPropertyTestBase(new MockRoleWithPermissionProperty());
+        $this->assertEquals($expectedCollection, $collection);
+    }
+
+    /**
+     * Tests the collectPermissions method when the role has a getPermissions() method
+     */
+    public function testCollectPermissionsMethod()
+    {
+        $expectedCollection = [
+            'guards' => [],
+            'roles'  => ['role-with-permission-method'],
+            'permissions' => [
+                'role-with-permission-method' => ['permission-method-a', 'permission-method-b'],
+            ],
+            'options' => [
+                'guest_role' => 'guest',
+                'protection_policy' => GuardInterface::POLICY_ALLOW,
+            ],
+        ];
+
+        $collection = $this->collectPermissionsPropertyTestBase(new MockRoleWithPermissionMethod());
+        $this->assertEquals($expectedCollection, $collection);
+    }
+
+    /**
+     * Base method for the *collectPermissionProperty tests
+     * @param RoleInterface $role
+     * @return array|\string[]
+     */
+    private function collectPermissionsPropertyTestBase(RoleInterface $role)
+    {
+        $serviceManager = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+
+        $application = $this->getMock('Zend\Mvc\Application', [], [], '', false);
+        $application->expects($this->once())->method('getServiceManager')->will($this->returnValue($serviceManager));
+
+        $mvcEvent = new MvcEvent();
+        $mvcEvent->setApplication($application);
+
+        $identity = $this->getMock('ZfcRbac\Identity\IdentityInterface');
+        $identity->expects($this->once())
+            ->method('getRoles')
+            ->will($this->returnValue([$role]));
+
+        $identityProvider = $this->getMock('ZfcRbac\Identity\IdentityProviderInterface');
+        $identityProvider->expects($this->once())
+            ->method('getIdentity')
+            ->will($this->returnValue($identity));
+
+        $roleProvider = $this->getMock(RoleProviderInterface::class);
+
+        $roleService = new RoleService($identityProvider,
+            $roleProvider,
+            new RecursiveRoleIteratorStrategy());
+
+        $serviceManager->expects($this->at(0))
+            ->method('get')
+            ->with('ZfcRbac\Service\RoleService')
+            ->will($this->returnValue($roleService));
+
+        $serviceManager->expects($this->at(1))
+            ->method('get')
+            ->with('ZfcRbac\Options\ModuleOptions')
+            ->will($this->returnValue(new ModuleOptions()));
+
+        $collector = new RbacCollector();
+        $collector->collect($mvcEvent);
+
+        $collector->unserialize($collector->serialize());
+        return $collector->getCollection();
+    }
+
+}
+
+class MockRoleWithPermissionProperty implements RoleInterface
+{
+    private $permissions = ['permission-property-a', 'permission-property-b'];
+
+    public function getName()
+    {
+        return 'role-with-permission-property';
+    }
+    public function hasPermission($permission)
+    {
+        return false;
+    }
+}
+
+class MockRoleWithPermissionMethod implements RoleInterface
+{
+    public function getPermissions()
+    {
+        return ['permission-method-a', 'permission-method-b'];
+    }
+
+    public function getName()
+    {
+        return 'role-with-permission-method';
+    }
+    public function hasPermission($permission)
+    {
+        return false;
     }
 }


### PR DESCRIPTION
If you are using a HierarchicalRole backed by doctrine where the children are lazy loaded, the collectPermissions method fails on a child role. This is because the child role is an instance of a doctrine proxy object, and does not have a permissions property to reflect.

Instead of immediately falling back to reflection, we can check if a getPermissions method exists on the role object and call that first.

Still not a very elegant solution, but it makes it a bit more robust.