### PR TITLE
Fix a bug with zend developer tools ZDT

### DIFF
--- a/src/ZfcRbac/Collector/RbacCollector.php
+++ b/src/ZfcRbac/Collector/RbacCollector.php
@@ -46,11 +46,6 @@ class RbacCollector implements CollectorInterface, Serializable
     /**
      * @var array
      */
-    protected $collection = [];
-
-    /**
-     * @var array
-     */
     protected $collectedGuards = [];
 
     /**
@@ -209,7 +204,12 @@ class RbacCollector implements CollectorInterface, Serializable
      */
     public function getCollection()
     {
-        return $this->collection;
+        return [
+            'guards'      => $this->collectedGuards,
+            'roles'       => $this->collectedRoles,
+            'permissions' => $this->collectedPermissions,
+            'options'     => $this->collectedOptions
+        ];
     }
 
     /**
@@ -217,12 +217,7 @@ class RbacCollector implements CollectorInterface, Serializable
      */
     public function serialize()
     {
-        return serialize([
-            'guards'      => $this->collectedGuards,
-            'roles'       => $this->collectedRoles,
-            'permissions' => $this->collectedPermissions,
-            'options'     => $this->collectedOptions
-        ]);
+        return serialize($this->getCollection());
     }
 
     /**


### PR DESCRIPTION
Latest ZDT update comes breaks ability to profile zfcrbac. Their commit can be seen :

https://github.com/zendframework/ZendDeveloperTools/commit/d3432681aa32177a741ad23604a40af9ad454acb#commitcomment-11090423

After a quick look, their fix seems relevant as relying on serializable behaviour is not very clear. 

This PR seems to fix the issue, by correctly returning collection as an array.