### PR TITLE
Add support for setter injection of IdentityProviderInterface and RoleeProviderInterface instances

### DIFF
--- a/src/ZfcRbac/Service/RoleService.php
+++ b/src/ZfcRbac/Service/RoleService.php
@@ -74,6 +74,26 @@ class RoleService
     }
 
     /**
+     * Set the identity provider
+     *
+     * @param IdentityProviderInterface $identityProvider
+     */
+    public function setIdentityProvider(IdentityProviderInterface $identityProvider)
+    {
+        $this->identityProvider = $identityProvider;
+    }
+
+    /**
+     * Set the identity provider
+     *
+     * @param RoleProviderInterface $roleProvider
+     */
+    public function setRoleProvider(RoleProviderInterface $roleProvider)
+    {
+        $this->roleProvider = $roleProvider;
+    }
+
+    /**
      * Set the guest role
      *
      * @param  string $guestRole


### PR DESCRIPTION
This solves problems such as the one described at http://stackoverflow.com/questions/29340127/zend-framework-2-abstractcontrollertestcase-and-zfcuser-zfcrbac