### PR TITLE
Allow optional context for getRoles

### DIFF
--- a/src/ZfcRbac/Identity/IdentityInterface.php
+++ b/src/ZfcRbac/Identity/IdentityInterface.php
@@ -29,7 +29,8 @@ interface IdentityInterface
     /**
      * Get the list of roles of this identity
      *
+     * @param  string $context Optional context for determining roles returned, eg. project name as context
      * @return string[]|\Rbac\Role\RoleInterface[]
      */
-    public function getRoles();
+    public function getRoles($context = null);
 }

--- a/src/ZfcRbac/Service/AuthorizationService.php
+++ b/src/ZfcRbac/Service/AuthorizationService.php
@@ -121,7 +121,7 @@ class AuthorizationService implements AuthorizationServiceInterface
      */
     public function isGranted($permission, $context = null)
     {
-        $roles = $this->roleService->getIdentityRoles();
+        $roles = $this->roleService->getIdentityRoles($context);
 
         if (empty($roles)) {
             return false;

--- a/src/ZfcRbac/Service/RoleService.php
+++ b/src/ZfcRbac/Service/RoleService.php
@@ -107,10 +107,11 @@ class RoleService
     /**
      * Get the identity roles from the current identity, applying some more logic
      *
+     * @param  string $context Optional context for determining roles returned, eg. project name as context
      * @return RoleInterface[]
      * @throws Exception\RuntimeException
      */
-    public function getIdentityRoles()
+    public function getIdentityRoles($context = null)
     {
         if (!$identity = $this->getIdentity()) {
             return $this->convertRoles([$this->guestRole]);
@@ -123,7 +124,7 @@ class RoleService
             ));
         }
 
-        return $this->convertRoles($identity->getRoles());
+        return $this->convertRoles($identity->getRoles($context));
     }
 
     /**


### PR DESCRIPTION
This allows the identity to return different roles for different contexts. A scenario would be a user having different roles for different projects and the project name is passed in as the context. Implements Solution 1 in https://github.com/ZF-Commons/zfc-rbac/issues/258#issuecomment-104590211