### PR TITLE
changes "@licence" with "@license"

### DIFF
--- a/src/ZfcRbac/Assertion/AssertionInterface.php
+++ b/src/ZfcRbac/Assertion/AssertionInterface.php
@@ -26,7 +26,7 @@ use ZfcRbac\Service\AuthorizationService;
  * @author  Michaël Gallego <mic.gallego@gmail.com>
  * @author  Aeneas Rekkas
  * @author  Daniel Gimenes  <daniel@danielgimenes.com.br>
- * @licence MIT
+ * @license MIT
  */
 interface AssertionInterface
 {

--- a/src/ZfcRbac/Assertion/AssertionPluginManager.php
+++ b/src/ZfcRbac/Assertion/AssertionPluginManager.php
@@ -25,7 +25,7 @@ use ZfcRbac\Exception;
  * Plugin manager to create assertions
  * 
  * @author  Aeneas Rekkas
- * @licence MIT
+ * @license MIT
  *
  * @method AssertionInterface get($name)
  */

--- a/src/ZfcRbac/Collector/RbacCollector.php
+++ b/src/ZfcRbac/Collector/RbacCollector.php
@@ -34,7 +34,7 @@ use ZfcRbac\Service\RoleService;
  * RbacCollector
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RbacCollector implements CollectorInterface, Serializable
 {

--- a/src/ZfcRbac/Exception/ExceptionInterface.php
+++ b/src/ZfcRbac/Exception/ExceptionInterface.php
@@ -22,7 +22,7 @@ namespace ZfcRbac\Exception;
  * Base exception interface for ZfcRbac
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 interface ExceptionInterface
 {

--- a/src/ZfcRbac/Exception/InvalidArgumentException.php
+++ b/src/ZfcRbac/Exception/InvalidArgumentException.php
@@ -24,7 +24,7 @@ use InvalidArgumentException as BaseInvalidArgumentException;
  * InvalidArgumentException
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class InvalidArgumentException extends BaseInvalidArgumentException implements ExceptionInterface
 {

--- a/src/ZfcRbac/Exception/RoleNotFoundException.php
+++ b/src/ZfcRbac/Exception/RoleNotFoundException.php
@@ -24,7 +24,7 @@ use RuntimeException as BaseRuntimeException;
  * Exception that is thrown when a role cannot be found (for instance from a provider)
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RoleNotFoundException extends BaseRuntimeException implements ExceptionInterface
 {

--- a/src/ZfcRbac/Exception/RuntimeException.php
+++ b/src/ZfcRbac/Exception/RuntimeException.php
@@ -24,7 +24,7 @@ use RuntimeException as BaseRuntimeException;
  * RuntimeException
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RuntimeException extends BaseRuntimeException implements ExceptionInterface
 {

--- a/src/ZfcRbac/Exception/UnauthorizedException.php
+++ b/src/ZfcRbac/Exception/UnauthorizedException.php
@@ -24,7 +24,7 @@ use RuntimeException as BaseRuntimeException;
  * Unauthorized exception
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class UnauthorizedException extends BaseRuntimeException implements UnauthorizedExceptionInterface
 {

--- a/src/ZfcRbac/Exception/UnauthorizedExceptionInterface.php
+++ b/src/ZfcRbac/Exception/UnauthorizedExceptionInterface.php
@@ -22,7 +22,7 @@ namespace ZfcRbac\Exception;
  * Interface for an unauthorized exception
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 interface UnauthorizedExceptionInterface extends ExceptionInterface
 {

--- a/src/ZfcRbac/Factory/AssertionPluginManagerFactory.php
+++ b/src/ZfcRbac/Factory/AssertionPluginManagerFactory.php
@@ -27,7 +27,7 @@ use ZfcRbac\Assertion\AssertionPluginManager;
  * Factory to create a assertion plugin manager
  * 
  * @author  Aeneas Rekkas
- * @licence MIT
+ * @license MIT
  */
 class AssertionPluginManagerFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/AuthenticationIdentityProviderFactory.php
+++ b/src/ZfcRbac/Factory/AuthenticationIdentityProviderFactory.php
@@ -26,7 +26,7 @@ use ZfcRbac\Identity\AuthenticationIdentityProvider;
  * Factory to create the authentication identity provider
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class AuthenticationIdentityProviderFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/AuthorizationServiceFactory.php
+++ b/src/ZfcRbac/Factory/AuthorizationServiceFactory.php
@@ -26,7 +26,7 @@ use ZfcRbac\Service\AuthorizationService;
  * Factory to create the authorization service
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class AuthorizationServiceFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/ControllerGuardFactory.php
+++ b/src/ZfcRbac/Factory/ControllerGuardFactory.php
@@ -27,7 +27,7 @@ use ZfcRbac\Guard\ControllerGuard;
  * Create a controller guard
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class ControllerGuardFactory implements FactoryInterface, MutableCreationOptionsInterface
 {

--- a/src/ZfcRbac/Factory/GuardPluginManagerFactory.php
+++ b/src/ZfcRbac/Factory/GuardPluginManagerFactory.php
@@ -27,7 +27,7 @@ use ZfcRbac\Guard\GuardPluginManager;
  * Factory to create a guard plugin manager
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class GuardPluginManagerFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/GuardsFactory.php
+++ b/src/ZfcRbac/Factory/GuardsFactory.php
@@ -25,7 +25,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  * Create a list of guards
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class GuardsFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/IsGrantedPluginFactory.php
+++ b/src/ZfcRbac/Factory/IsGrantedPluginFactory.php
@@ -26,7 +26,7 @@ use ZfcRbac\Mvc\Controller\Plugin\IsGranted;
  * Create the IsGranted controller plugin
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class IsGrantedPluginFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/IsGrantedViewHelperFactory.php
+++ b/src/ZfcRbac/Factory/IsGrantedViewHelperFactory.php
@@ -26,7 +26,7 @@ use ZfcRbac\View\Helper\IsGranted;
  * Create the IsGranted view helper
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class IsGrantedViewHelperFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/ModuleOptionsFactory.php
+++ b/src/ZfcRbac/Factory/ModuleOptionsFactory.php
@@ -26,7 +26,7 @@ use ZfcRbac\Options\ModuleOptions;
  * Factory for the module options
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class ModuleOptionsFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/ObjectRepositoryRoleProviderFactory.php
+++ b/src/ZfcRbac/Factory/ObjectRepositoryRoleProviderFactory.php
@@ -28,7 +28,7 @@ use ZfcRbac\Role\ObjectRepositoryRoleProvider;
  * Factory used to create an object repository role provider
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class ObjectRepositoryRoleProviderFactory implements FactoryInterface, MutableCreationOptionsInterface
 {

--- a/src/ZfcRbac/Factory/RbacFactory.php
+++ b/src/ZfcRbac/Factory/RbacFactory.php
@@ -26,7 +26,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RbacFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/RedirectStrategyFactory.php
+++ b/src/ZfcRbac/Factory/RedirectStrategyFactory.php
@@ -26,7 +26,7 @@ use ZfcRbac\View\Strategy\RedirectStrategy;
  * Factory to create a redirect strategy
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RedirectStrategyFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/RoleProviderPluginManagerFactory.php
+++ b/src/ZfcRbac/Factory/RoleProviderPluginManagerFactory.php
@@ -27,7 +27,7 @@ use ZfcRbac\Role\RoleProviderPluginManager;
  * Factory to create a role provider plugin manager
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RoleProviderPluginManagerFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/RoleServiceFactory.php
+++ b/src/ZfcRbac/Factory/RoleServiceFactory.php
@@ -26,7 +26,7 @@ use ZfcRbac\Service\RoleService;
  * Factory to create the role service
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RoleServiceFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Factory/RouteGuardFactory.php
+++ b/src/ZfcRbac/Factory/RouteGuardFactory.php
@@ -27,7 +27,7 @@ use ZfcRbac\Guard\RouteGuard;
  * Create a route guard
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RouteGuardFactory implements FactoryInterface, MutableCreationOptionsInterface
 {

--- a/src/ZfcRbac/Factory/UnauthorizedStrategyFactory.php
+++ b/src/ZfcRbac/Factory/UnauthorizedStrategyFactory.php
@@ -26,7 +26,7 @@ use ZfcRbac\View\Strategy\UnauthorizedStrategy;
  * Factory to create an unauthorized strategy
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class UnauthorizedStrategyFactory implements FactoryInterface
 {

--- a/src/ZfcRbac/Guard/AbstractGuard.php
+++ b/src/ZfcRbac/Guard/AbstractGuard.php
@@ -27,7 +27,7 @@ use ZfcRbac\Exception;
  * Abstract guard that hook on the MVC workflow
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 abstract class AbstractGuard implements GuardInterface
 {

--- a/src/ZfcRbac/Guard/ControllerGuard.php
+++ b/src/ZfcRbac/Guard/ControllerGuard.php
@@ -25,7 +25,7 @@ use ZfcRbac\Service\RoleService;
  * A controller guard can protect a controller and a set of actions
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class ControllerGuard extends AbstractGuard
 {

--- a/src/ZfcRbac/Guard/GuardInterface.php
+++ b/src/ZfcRbac/Guard/GuardInterface.php
@@ -32,7 +32,7 @@ use Zend\Mvc\MvcEvent;
  * proper authorization service (see the doc for more details)
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 interface GuardInterface extends ListenerAggregateInterface
 {

--- a/src/ZfcRbac/Guard/GuardPluginManager.php
+++ b/src/ZfcRbac/Guard/GuardPluginManager.php
@@ -27,7 +27,7 @@ use ZfcRbac\Exception;
  * @method GuardInterface get($name)
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class GuardPluginManager extends AbstractPluginManager
 {

--- a/src/ZfcRbac/Guard/ProtectionPolicyTrait.php
+++ b/src/ZfcRbac/Guard/ProtectionPolicyTrait.php
@@ -22,7 +22,7 @@ namespace ZfcRbac\Guard;
  * Trait that is can be used for any guard that uses the protection policy pattern
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 trait ProtectionPolicyTrait
 {

--- a/src/ZfcRbac/Guard/RouteGuard.php
+++ b/src/ZfcRbac/Guard/RouteGuard.php
@@ -26,7 +26,7 @@ use ZfcRbac\Service\RoleService;
  * A route guard can protect a route or a hierarchy of routes (using simple wildcard pattern)
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RouteGuard extends AbstractGuard
 {

--- a/src/ZfcRbac/Identity/AuthenticationIdentityProvider.php
+++ b/src/ZfcRbac/Identity/AuthenticationIdentityProvider.php
@@ -25,7 +25,7 @@ use ZfcRbac\Exception;
  * This provider uses the Zend authentication service to fetch the identity
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class AuthenticationIdentityProvider implements IdentityProviderInterface
 {

--- a/src/ZfcRbac/Identity/IdentityInterface.php
+++ b/src/ZfcRbac/Identity/IdentityInterface.php
@@ -22,7 +22,7 @@ namespace ZfcRbac\Identity;
  * Interface for an identity
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 interface IdentityInterface
 {

--- a/src/ZfcRbac/Identity/IdentityProviderInterface.php
+++ b/src/ZfcRbac/Identity/IdentityProviderInterface.php
@@ -22,7 +22,7 @@ namespace ZfcRbac\Identity;
  * An identity provider is an object that returns an object that implement ZfcRbac\Identity\IdentityInterface
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 interface IdentityProviderInterface
 {

--- a/src/ZfcRbac/Module.php
+++ b/src/ZfcRbac/Module.php
@@ -26,7 +26,7 @@ use Zend\ModuleManager\Feature\ConfigProviderInterface;
  * Module class for ZfcRbac
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class Module implements BootstrapListenerInterface, ConfigProviderInterface
 {

--- a/src/ZfcRbac/Mvc/Controller/Plugin/IsGranted.php
+++ b/src/ZfcRbac/Mvc/Controller/Plugin/IsGranted.php
@@ -25,7 +25,7 @@ use ZfcRbac\Service\AuthorizationService;
  * Controller plugin that allows to test a permission in a controller
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class IsGranted extends AbstractPlugin
 {

--- a/src/ZfcRbac/Options/ModuleOptions.php
+++ b/src/ZfcRbac/Options/ModuleOptions.php
@@ -26,7 +26,7 @@ use ZfcRbac\Guard\GuardInterface;
  * Options for ZfcRbac module
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class ModuleOptions extends AbstractOptions
 {

--- a/src/ZfcRbac/Options/RedirectStrategyOptions.php
+++ b/src/ZfcRbac/Options/RedirectStrategyOptions.php
@@ -24,7 +24,7 @@ use Zend\Stdlib\AbstractOptions;
  * Redirect strategy options
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RedirectStrategyOptions extends AbstractOptions
 {

--- a/src/ZfcRbac/Options/UnauthorizedStrategyOptions.php
+++ b/src/ZfcRbac/Options/UnauthorizedStrategyOptions.php
@@ -24,7 +24,7 @@ use Zend\Stdlib\AbstractOptions;
  * Unauthorized strategy options
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class UnauthorizedStrategyOptions extends AbstractOptions
 {

--- a/src/ZfcRbac/Role/InMemoryRoleProvider.php
+++ b/src/ZfcRbac/Role/InMemoryRoleProvider.php
@@ -37,7 +37,7 @@ use Rbac\Role\Role;
  * follow the format :)
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class InMemoryRoleProvider implements RoleProviderInterface
 {

--- a/src/ZfcRbac/Role/ObjectRepositoryRoleProvider.php
+++ b/src/ZfcRbac/Role/ObjectRepositoryRoleProvider.php
@@ -25,7 +25,7 @@ use ZfcRbac\Exception\RoleNotFoundException;
  * Role provider that uses Doctrine object repository to fetch roles
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class ObjectRepositoryRoleProvider implements RoleProviderInterface
 {

--- a/src/ZfcRbac/Role/RoleProviderInterface.php
+++ b/src/ZfcRbac/Role/RoleProviderInterface.php
@@ -25,7 +25,7 @@ namespace ZfcRbac\Role;
  * or from memory
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 interface RoleProviderInterface
 {

--- a/src/ZfcRbac/Role/RoleProviderPluginManager.php
+++ b/src/ZfcRbac/Role/RoleProviderPluginManager.php
@@ -27,7 +27,7 @@ use ZfcRbac\Exception;
  * @method RoleProviderInterface get($name)
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RoleProviderPluginManager extends AbstractPluginManager
 {

--- a/src/ZfcRbac/Service/AuthorizationService.php
+++ b/src/ZfcRbac/Service/AuthorizationService.php
@@ -30,7 +30,7 @@ use ZfcRbac\Identity\IdentityInterface;
  * granted a permission
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class AuthorizationService
 {

--- a/src/ZfcRbac/Service/RoleService.php
+++ b/src/ZfcRbac/Service/RoleService.php
@@ -32,7 +32,7 @@ use Rbac\Traversal\Strategy\TraversalStrategyInterface;
  * Role service
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RoleService
 {

--- a/src/ZfcRbac/View/Helper/IsGranted.php
+++ b/src/ZfcRbac/View/Helper/IsGranted.php
@@ -25,7 +25,7 @@ use ZfcRbac\Service\AuthorizationService;
  * View helper that allows to test a permission in a view
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class IsGranted extends AbstractHelper
 {

--- a/src/ZfcRbac/View/Strategy/AbstractStrategy.php
+++ b/src/ZfcRbac/View/Strategy/AbstractStrategy.php
@@ -26,7 +26,7 @@ use Zend\Mvc\MvcEvent;
  * Abstract strategy for any unauthorized access
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 abstract class AbstractStrategy extends AbstractListenerAggregate
 {

--- a/src/ZfcRbac/View/Strategy/RedirectStrategy.php
+++ b/src/ZfcRbac/View/Strategy/RedirectStrategy.php
@@ -28,7 +28,7 @@ use ZfcRbac\Options\RedirectStrategyOptions;
  * This strategy redirects to another route when a user is unauthorized
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class RedirectStrategy extends AbstractStrategy
 {

--- a/src/ZfcRbac/View/Strategy/UnauthorizedStrategy.php
+++ b/src/ZfcRbac/View/Strategy/UnauthorizedStrategy.php
@@ -29,7 +29,7 @@ use ZfcRbac\Options\UnauthorizedStrategyOptions;
  * This strategy renders a specific template when a user is unauthorized
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
- * @licence MIT
+ * @license MIT
  */
 class UnauthorizedStrategy extends AbstractStrategy
 {


### PR DESCRIPTION
The proper docblock is "@license" and it needs to be proper so that annotation parsing libraries are skipping this annotation as it is a phpdoc one.

Just ran into an issue where we were adding the exception to the logging. Our logger is configured to basically do `if is_object($attachment) : JMSSerialize($attachment)` and as JMS Serializer uses annotations internally to exclude some stuff, we ran into the funny exception

```
[Semantical Error] The annotation "@licence" in class ZfcRbac\Exception\UnauthorizedException was never imported. Did you maybe forget to add a "use" statement for this annotation?`
```

This PR fixes that :)

Kudos to @grizzm0 for noticing the mistake in the first place