### PR TITLE
Change/remove auth service from assertions

### DIFF
--- a/src/Assertion/AssertionInterface.php
+++ b/src/Assertion/AssertionInterface.php
@@ -19,7 +19,6 @@
 namespace ZfcRbac\Assertion;
 
 use ZfcRbac\Identity\IdentityInterface;
-use ZfcRbac\Service\AuthorizationServiceInterface;
 
 /**
  * Interface that you can implement for dynamic assertions
@@ -34,13 +33,11 @@ interface AssertionInterface
     /**
      * Check if this assertion is true
      *
-     * @param  AuthorizationServiceInterface $authorizationService
      * @param  IdentityInterface             $identity
      * @param  mixed                         $context
      * @return bool
      */
     public function assert(
-        AuthorizationServiceInterface $authorizationService,
         IdentityInterface $identity = null,
         $context = null
     );

--- a/src/Service/AuthorizationService.php
+++ b/src/Service/AuthorizationService.php
@@ -133,17 +133,17 @@ class AuthorizationService implements AuthorizationServiceInterface
     protected function assert($assertion, IdentityInterface $identity = null, $context = null)
     {
         if (is_callable($assertion)) {
-            return $assertion($this, $identity, $context);
+            return $assertion($identity, $context);
         }
 
         if ($assertion instanceof AssertionInterface) {
-            return $assertion->assert($this, $identity, $context);
+            return $assertion->assert($identity, $context);
         }
 
         if (is_string($assertion)) {
             $assertion = $this->assertionPluginManager->get($assertion);
 
-            return $assertion->assert($this, $identity, $context);
+            return $assertion->assert($identity, $context);
         }
 
         throw new Exception\InvalidArgumentException(sprintf(

--- a/test/Asset/SimpleAssertion.php
+++ b/test/Asset/SimpleAssertion.php
@@ -20,7 +20,6 @@ namespace ZfcRbacTest\Asset;
 
 use ZfcRbac\Assertion\AssertionInterface;
 use ZfcRbac\Identity\IdentityInterface;
-use ZfcRbac\Service\AuthorizationServiceInterface;
 
 class SimpleAssertion implements AssertionInterface
 {
@@ -33,7 +32,6 @@ class SimpleAssertion implements AssertionInterface
      * {@inheritDoc}
      */
     public function assert(
-        AuthorizationServiceInterface $authorizationService,
         IdentityInterface $identity = null,
         $context = null
     ) {


### PR DESCRIPTION
This PR removes the AuthorizationService as argument to Assertions.

This mean you now should use a factory to instantiate assertions, but only when you actually use the AuthorizationService.