### PR TITLE
Change/pass context parameter to RoleService::getIdentityRoles

### DIFF
--- a/config/dependencies.global.php
+++ b/config/dependencies.global.php
@@ -23,7 +23,7 @@ return [
             ZfcRbac\Options\ModuleOptions::class                 => ZfcRbac\Container\ModuleOptionsFactory::class,
             ZfcRbac\Role\RoleProviderPluginManager::class        => ZfcRbac\Container\RoleProviderPluginManagerFactory::class,
             ZfcRbac\Service\AuthorizationServiceInterface::class => ZfcRbac\Container\AuthorizationServiceFactory::class,
-            ZfcRbac\Service\RoleService::class                   => ZfcRbac\Container\RoleServiceFactory::class,
+            ZfcRbac\Service\RoleServiceInterface::class          => ZfcRbac\Container\RoleServiceFactory::class,
         ],
     ],
 

--- a/src/Service/AuthorizationService.php
+++ b/src/Service/AuthorizationService.php
@@ -106,7 +106,7 @@ class AuthorizationService implements AuthorizationServiceInterface
      */
     public function isGranted($identity, $permission, $context = null)
     {
-        $roles = $this->roleService->getIdentityRoles($identity);
+        $roles = $this->roleService->getIdentityRoles($identity, $context);
 
         if (empty($roles)) {
             return false;

--- a/src/Service/AuthorizationService.php
+++ b/src/Service/AuthorizationService.php
@@ -39,7 +39,7 @@ class AuthorizationService implements AuthorizationServiceInterface
     protected $rbac;
 
     /**
-     * @var RoleService
+     * @var RoleServiceInterface
      */
     protected $roleService;
 
@@ -57,11 +57,14 @@ class AuthorizationService implements AuthorizationServiceInterface
      * Constructor
      *
      * @param Rbac                   $rbac
-     * @param RoleService            $roleService
+     * @param RoleServiceInterface   $roleService
      * @param AssertionPluginManager $assertionPluginManager
      */
-    public function __construct(Rbac $rbac, RoleService $roleService, AssertionPluginManager $assertionPluginManager)
-    {
+    public function __construct(
+        Rbac $rbac,
+        RoleServiceInterface $roleService,
+        AssertionPluginManager $assertionPluginManager
+    ) {
         $this->rbac                   = $rbac;
         $this->roleService            = $roleService;
         $this->assertionPluginManager = $assertionPluginManager;

--- a/src/Service/RoleService.php
+++ b/src/Service/RoleService.php
@@ -87,9 +87,10 @@ class RoleService
      * Get the identity roles from the current identity, applying some more logic
      *
      * @param IdentityInterface $identity
+     * @param null              $context
      * @return RoleInterface[]
      */
-    public function getIdentityRoles(IdentityInterface $identity = null)
+    public function getIdentityRoles(IdentityInterface $identity = null, $context = null)
     {
         if (null === $identity) {
             return $this->convertRoles([$this->guestRole]);

--- a/src/Service/RoleService.php
+++ b/src/Service/RoleService.php
@@ -29,7 +29,7 @@ use ZfcRbac\Role\RoleProviderInterface;
  * @author  Michaël Gallego <mic.gallego@gmail.com>
  * @licence MIT
  */
-class RoleService
+class RoleService implements RoleServiceInterface
 {
 
     /**

--- a/src/Service/RoleServiceInterface.php
+++ b/src/Service/RoleServiceInterface.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfcRbac\Service;
+
+use Rbac\Role\RoleInterface;
+use ZfcRbac\Identity\IdentityInterface;
+
+/**
+ * Role service
+ *
+ * @author  Michaël Gallego <mic.gallego@gmail.com>
+ * @licence MIT
+ */
+interface RoleServiceInterface
+{
+    /**
+     * Get the identity roles from the current identity, applying some more logic
+     *
+     * @param IdentityInterface $identity
+     * @param null              $context
+     * @return RoleInterface[]
+     */
+    public function getIdentityRoles(IdentityInterface $identity = null, $context = null);
+}

--- a/src/Service/RoleServiceInterface.php
+++ b/src/Service/RoleServiceInterface.php
@@ -32,8 +32,8 @@ interface RoleServiceInterface
     /**
      * Get the identity roles from the current identity, applying some more logic
      *
-     * @param IdentityInterface $identity
-     * @param null              $context
+     * @param null|IdentityInterface $identity
+     * @param mixed                   $context
      * @return RoleInterface[]
      */
     public function getIdentityRoles(IdentityInterface $identity = null, $context = null);

--- a/test/Service/AuthorizationServiceTest.php
+++ b/test/Service/AuthorizationServiceTest.php
@@ -22,6 +22,7 @@ use Rbac\Rbac;
 use Rbac\Role\RoleInterface;
 use ZfcRbac\Service\AuthorizationService;
 use ZfcRbac\Service\RoleService;
+use ZfcRbac\Service\RoleServiceInterface;
 use ZfcRbacTest\Asset\FlatRole;
 use ZfcRbacTest\Asset\Identity;
 use ZfcRbacTest\Asset\SimpleAssertion;
@@ -271,5 +272,19 @@ class AuthorizationServiceTest extends \PHPUnit_Framework_TestCase
         $authorizationService->setAssertion('bar', null);
 
         $this->assertFalse($authorizationService->hasAssertion('bar'));
+    }
+
+    public function testContextIsPassedToRoleService()
+    {
+        $identity               = new Identity([]);
+        $context                = 'context';
+
+        $rbac                   = $this->getMockBuilder(Rbac::class)->disableOriginalConstructor()->getMock();
+        $roleService            = $this->getMockBuilder(RoleServiceInterface::class)->disableOriginalConstructor()->getMock();
+        $assertionPluginManager = $this->getMockBuilder(AssertionPluginManager::class)->disableOriginalConstructor()->getMock();
+        $authorizationService   = new AuthorizationService($rbac, $roleService, $assertionPluginManager);
+
+        $roleService->expects($this->once())->method('getIdentityRoles')->with($identity, $context)->willReturn([]);
+        $authorizationService->isGranted($identity, 'foo', $context);
     }
 }


### PR DESCRIPTION
This PR will pass the context to the RoleService::getIdentityRoles from within the AuthorizationService. Additionally it adds an RoleServiceInterface so the RoleService can be changed.

Not a breaking change.

As requested by @Wilt in https://github.com/ZF-Commons/zfc-rbac/pull/316