### PR TITLE
Change/pass permission as param to assertions

### DIFF
--- a/src/Assertion/AssertionInterface.php
+++ b/src/Assertion/AssertionInterface.php
@@ -33,11 +33,13 @@ interface AssertionInterface
     /**
      * Check if this assertion is true
      *
-     * @param  IdentityInterface             $identity
-     * @param  mixed                         $context
+     * @param string            $permission
+     * @param IdentityInterface $identity
+     * @param mixed             $context
      * @return bool
      */
     public function assert(
+        $permission,
         IdentityInterface $identity = null,
         $context = null
     );

--- a/src/Service/AuthorizationService.php
+++ b/src/Service/AuthorizationService.php
@@ -117,7 +117,7 @@ class AuthorizationService implements AuthorizationServiceInterface
         }
 
         if ($this->hasAssertion($permission)) {
-            return $this->assert($this->assertions[(string) $permission], $identity, $context);
+            return $this->assert($this->assertions[(string) $permission], $permission, $identity, $context);
         }
 
         return true;
@@ -125,25 +125,25 @@ class AuthorizationService implements AuthorizationServiceInterface
 
     /**
      * @param string|callable|AssertionInterface $assertion
+     * @param string                             $permission
      * @param IdentityInterface                  $identity
      * @param mixed                              $context
      * @return bool
-     * @throws Exception\InvalidArgumentException If an invalid assertion is passed
      */
-    protected function assert($assertion, IdentityInterface $identity = null, $context = null)
+    protected function assert($assertion, $permission, IdentityInterface $identity = null, $context = null)
     {
         if (is_callable($assertion)) {
-            return $assertion($identity, $context);
+            return $assertion($permission, $identity, $context);
         }
 
         if ($assertion instanceof AssertionInterface) {
-            return $assertion->assert($identity, $context);
+            return $assertion->assert($permission, $identity, $context);
         }
 
         if (is_string($assertion)) {
             $assertion = $this->assertionPluginManager->get($assertion);
 
-            return $assertion->assert($identity, $context);
+            return $assertion->assert($permission, $identity, $context);
         }
 
         throw new Exception\InvalidArgumentException(sprintf(

--- a/test/Asset/SimpleAssertion.php
+++ b/test/Asset/SimpleAssertion.php
@@ -32,6 +32,7 @@ class SimpleAssertion implements AssertionInterface
      * {@inheritDoc}
      */
     public function assert(
+        $permission,
         IdentityInterface $identity = null,
         $context = null
     ) {

--- a/test/Service/AuthorizationServiceTest.php
+++ b/test/Service/AuthorizationServiceTest.php
@@ -220,7 +220,7 @@ class AuthorizationServiceTest extends \PHPUnit_Framework_TestCase
         $authorizationService = new AuthorizationService($rbac, $roleService, $assertionPluginManager);
         $authorizationService->setAssertion(
             'foo',
-            function (IdentityInterface $identity = null, $context = null) use ($authorizationService, &$called) {
+            function ($permission, IdentityInterface $identity = null, $context = null) use ($authorizationService, &$called) {
                 $called = true;
 
                 return false;


### PR DESCRIPTION
As proposed this PR passes the requested permission name to the Assertion::assert method, so the assertion can assert based on that information.

Note: based on an PR #342 that is also a proposal. To avoid merge conflicts please review/merge that one first.