### PR TITLE
Added config option for authorization service instead of hard-coded one

### DIFF
--- a/docs/07. Cookbook.md
+++ b/docs/07. Cookbook.md
@@ -750,10 +750,8 @@ To use the authentication service from ZfcUser, just add the following alias in 
 
 ```php
 return [
-    'service_manager' => [
-        'aliases' => [
-            'Zend\Authentication\AuthenticationService' => 'zfcuser_auth_service'
-        ]
+    'zfc_rbac' => [
+        'authentication_service' => 'zfcuser_auth_service'
     ]
 ];
 ```

--- a/src/ZfcRbac/Factory/AuthenticationIdentityProviderFactory.php
+++ b/src/ZfcRbac/Factory/AuthenticationIdentityProviderFactory.php
@@ -39,8 +39,10 @@ class AuthenticationIdentityProviderFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
+        /* @var \ZfcRbac\Options\ModuleOptions $moduleOptions */
+        $moduleOptions = $container->get('ZfcRbac\Options\ModuleOptions');
         /* @var \Zend\Authentication\AuthenticationService $authenticationProvider */
-        $authenticationProvider = $container->get('Zend\Authentication\AuthenticationService');
+        $authenticationProvider = $container->get($moduleOptions->getAuthenticationService());
 
         return new AuthenticationIdentityProvider($authenticationProvider);
     }

--- a/src/ZfcRbac/Factory/RedirectStrategyFactory.php
+++ b/src/ZfcRbac/Factory/RedirectStrategyFactory.php
@@ -42,7 +42,7 @@ class RedirectStrategyFactory implements FactoryInterface
         /* @var \ZfcRbac\Options\ModuleOptions $moduleOptions */
         $moduleOptions = $container->get('ZfcRbac\Options\ModuleOptions');
         /** @var \Zend\Authentication\AuthenticationService $authenticationService */
-        $authenticationService = $container->get('Zend\Authentication\AuthenticationService');
+        $authenticationService = $container->get($moduleOptions->getAuthenticationService());
 
         return new RedirectStrategy($moduleOptions->getRedirectStrategy(), $authenticationService);
     }

--- a/src/ZfcRbac/Options/ModuleOptions.php
+++ b/src/ZfcRbac/Options/ModuleOptions.php
@@ -87,6 +87,13 @@ class ModuleOptions extends AbstractOptions
     protected $redirectStrategy;
 
     /**
+     * Authentication service name
+     *
+     * @var string
+     */
+    protected $authenticationService = 'Zend\Authentication\AuthenticationService';
+
+    /**
      * Constructor
      *
      * {@inheritDoc}
@@ -283,5 +290,25 @@ class ModuleOptions extends AbstractOptions
         }
 
         return $this->redirectStrategy;
+    }
+
+    /**
+     * Get authentication service name
+     *
+     * @return string
+     */
+    public function getAuthenticationService()
+    {
+        return $this->authenticationService;
+    }
+
+    /**
+     * Set authentication service name
+     *
+     * @param string $authenticationService
+     */
+    public function setAuthenticationService($authenticationService)
+    {
+        $this->authenticationService = $authenticationService;
     }
 }

--- a/tests/ZfcRbacTest/Factory/AuthenticationIdentityProviderFactoryTest.php
+++ b/tests/ZfcRbacTest/Factory/AuthenticationIdentityProviderFactoryTest.php
@@ -20,6 +20,7 @@ namespace ZfcRbacTest\Factory;
 
 use Zend\ServiceManager\ServiceManager;
 use ZfcRbac\Factory\AuthenticationIdentityProviderFactory;
+use ZfcRbac\Options\ModuleOptions;
 
 /**
  * @covers \ZfcRbac\Factory\AuthenticationIdentityProviderFactory
@@ -29,6 +30,7 @@ class AuthenticationIdentityProviderFactoryTest extends \PHPUnit_Framework_TestC
     public function testFactory()
     {
         $serviceManager = new ServiceManager();
+        $serviceManager->setService('ZfcRbac\Options\ModuleOptions', new ModuleOptions());
         $serviceManager->setService(
             'Zend\Authentication\AuthenticationService',
             $this->getMock('Zend\Authentication\AuthenticationService')

--- a/tests/ZfcRbacTest/Factory/RedirectStrategyFactoryTest.php
+++ b/tests/ZfcRbacTest/Factory/RedirectStrategyFactoryTest.php
@@ -35,6 +35,9 @@ class RedirectStrategyFactoryTest extends \PHPUnit_Framework_TestCase
         $moduleOptionsMock->expects($this->once())
                           ->method('getRedirectStrategy')
                           ->will($this->returnValue($redirectStrategyOptions));
+        $moduleOptionsMock->expects($this->once())
+            ->method('getAuthenticationService')
+            ->will($this->returnValue('Zend\Authentication\AuthenticationService'));
 
         $authenticationServiceMock = $this->getMock('Zend\Authentication\AuthenticationService');
 

--- a/tests/ZfcRbacTest/Options/ModuleOptionsTest.php
+++ b/tests/ZfcRbacTest/Options/ModuleOptionsTest.php
@@ -44,6 +44,7 @@ class ModuleOptionsTest extends \PHPUnit_Framework_TestCase
     public function testSettersAndGetters()
     {
         $moduleOptions = new ModuleOptions([
+            'authentication_service' => 'authentication_service_name',
             'identity_provider'     => 'IdentityProvider',
             'guest_role'            => 'unknown',
             'guards'                => [],
@@ -61,6 +62,7 @@ class ModuleOptionsTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
+        $this->assertEquals('authentication_service_name', $moduleOptions->getAuthenticationService());
         $this->assertEquals('IdentityProvider', $moduleOptions->getIdentityProvider());
         $this->assertEquals('unknown', $moduleOptions->getGuestRole());
         $this->assertEquals([], $moduleOptions->getGuards());


### PR DESCRIPTION
There are problems with migration to laminas I can't change `Zend\Authentication\AuthenticationService` to `Laminas\Authentication\AuthenticationService`
then I add an alias in service manager for this but in some cases, I can't use this workaround and would be nice if this would be not hardcoded.
now you can just add to config this
```php
'zfc_rbac' => [
  'authentication_service' => 'Laminas\Authentication\AuthenticationService' // or 'zfcuser_auth_service' in case of zfcUser
];
```
This is not a BC break because default still is `Zend\Authentication\AuthenticationService`